### PR TITLE
Render import preview with the shared export Question component

### DIFF
--- a/mono/src/lib/export/template/QCM.svelte
+++ b/mono/src/lib/export/template/QCM.svelte
@@ -127,8 +127,9 @@
     width: 24px;
     height: 24px;
     padding: 0 8px;
-    background: var(--accent);
-    color: var(--accent-foreground);
+    /* Black by default (fixed across themes), green when correct. */
+    background: #111827;
+    color: #ffffff;
     border-radius: var(--radius);
     font-size: 12px;
     font-weight: 600;

--- a/mono/src/lib/export/template/Question.svelte
+++ b/mono/src/lib/export/template/Question.svelte
@@ -69,8 +69,10 @@
     align-items: center;
     gap: 8px;
     padding: 5px 7px;
-    background: var(--accent);
-    color: var(--accent-foreground);
+    /* Black title bar, intentionally fixed across light/dark themes (no token
+       stays black in dark mode) and shared by the import + export previews. */
+    background: #111827;
+    color: #ffffff;
     font-size: 15px;
     font-weight: 600;
   }
@@ -84,7 +86,8 @@
   .checkbox-wrapper input {
     width: 14px;
     height: 14px;
-    accent-color: var(--accent-foreground);
+    /* On the fixed black title bar regardless of theme. */
+    accent-color: #ffffff;
     cursor: pointer;
   }
 

--- a/mono/src/lib/import/helper/toQuestionType.ts
+++ b/mono/src/lib/import/helper/toQuestionType.ts
@@ -1,0 +1,39 @@
+import type { QuestionType } from "$lib/export/helper";
+import type { QCM } from "./question";
+
+/**
+ * Adapt the import-side `QCM` model into the export-side `QuestionType` so the
+ * import preview can be rendered with the exact same `Question.svelte`
+ * component the export route uses. Keeping a single renderer guarantees both
+ * routes stay visually and behaviourally in sync.
+ */
+export function qcmToQuestionType(qcm: QCM): QuestionType {
+  // The export renderer expects each prompt entry to be an Element it reads
+  // `innerHTML` from. Wrap the rich-text string in a detached element so the
+  // markup survives untouched.
+  const promptEl =
+    typeof document !== "undefined"
+      ? document.createElement("div")
+      : ({ innerHTML: "" } as unknown as HTMLDivElement);
+  promptEl.innerHTML = qcm.prompt?.toString() ?? "";
+
+  return {
+    title: qcm.id?.toString() ?? "",
+    type: "QCM",
+    prompt: [promptEl],
+    answers: qcm.answers.map((answer, i) => ({
+      txt: answer.prompt?.toString() ?? "",
+      // No explicit scoring exists on the import side; mirror the historical
+      // PreviewTAO weighting (correct = 3, incorrect = -1).
+      point: answer.correct ? "3" : "-1",
+      id: String(i),
+      correct: answer.correct,
+    })),
+    maxLenght: [],
+    show: true,
+  };
+}
+
+export function qcmsToQuestionTypes(qcms: QCM[]): QuestionType[] {
+  return qcms.map(qcmToQuestionType);
+}

--- a/mono/src/lib/import/helper/toQuestionType.ts
+++ b/mono/src/lib/import/helper/toQuestionType.ts
@@ -2,6 +2,21 @@ import type { QuestionType } from "$lib/export/helper";
 import type { QCM } from "./question";
 
 /**
+ * Spreadsheet cells can carry rich text, whose string form (`.r`) is raw
+ * SpreadsheetML markup such as `<t>Question 01</t>`. That was harmless when the
+ * legacy preview rendered it via `{@html}` (the browser dropped the unknown
+ * `<t>` tag), but the shared export component renders the title as plain text,
+ * so the tags would leak through. Strip any markup to get clean plain text.
+ */
+function plainText(txt: { w?: string; r?: string; v?: string } | undefined): string {
+  if (!txt) return "";
+  const raw = txt.w ?? txt.r ?? txt.v ?? "";
+  return String(raw)
+    .replace(/<[^>]*>/g, "")
+    .trim();
+}
+
+/**
  * Adapt the import-side `QCM` model into the export-side `QuestionType` so the
  * import preview can be rendered with the exact same `Question.svelte`
  * component the export route uses. Keeping a single renderer guarantees both
@@ -18,7 +33,7 @@ export function qcmToQuestionType(qcm: QCM): QuestionType {
   promptEl.innerHTML = qcm.prompt?.toString() ?? "";
 
   return {
-    title: qcm.id?.toString() ?? "",
+    title: plainText(qcm.id),
     type: "QCM",
     prompt: [promptEl],
     answers: qcm.answers.map((answer, i) => ({
@@ -33,6 +48,7 @@ export function qcmToQuestionType(qcm: QCM): QuestionType {
     show: true,
   };
 }
+
 
 export function qcmsToQuestionTypes(qcms: QCM[]): QuestionType[] {
   return qcms.map(qcmToQuestionType);

--- a/mono/src/routes/import/+page.svelte
+++ b/mono/src/routes/import/+page.svelte
@@ -2,7 +2,9 @@
   import { get } from "svelte/store";
   import * as XLSX from "xlsx";
   import Menu from "$lib/import/Menu.svelte";
-  import PreviewTao from "$lib/import/preview/PreviewTAO.svelte";
+  import QuestionPreview from "$lib/export/template/Question.svelte";
+  import { showAnswer } from "$lib/export/store";
+  import type { QuestionType } from "$lib/export/helper";
   import DropZone from "$lib/import/Input/DropZone.svelte";
   import {
     alternative,
@@ -21,12 +23,26 @@
     titleColumn,
   } from "$lib/import/helper/store";
   import { QCM, Question } from "$lib/import/helper/question";
+  import { qcmsToQuestionTypes } from "$lib/import/helper/toQuestionType";
   import { sidebarEnabled, sidebarOpen } from "$lib/sidebar";
   import { EmptyState } from "$lib/ui";
   import { FileSpreadsheet } from "lucide-svelte";
 
   let questions = $state<QCM[]>([]);
+  let renderQuestions = $state<QuestionType[]>([]);
   let workbook = $state<XLSX.WorkBook | undefined>(undefined);
+
+  // Render the import preview with the same component the export route uses by
+  // adapting the parsed QCMs into the shared QuestionType model.
+  $effect(() => {
+    renderQuestions = qcmsToQuestionTypes(questions);
+  });
+
+  // Keep the shared renderer's answer visibility in sync with the import-side
+  // "hide answers" toggle (Question.svelte / QCM.svelte read the export store).
+  $effect(() => {
+    showAnswer.set(!$hideAnswer);
+  });
 
   $effect(() => {
     sidebarEnabled.set(true);
@@ -86,7 +102,14 @@
 
     <div class="main-area">
       {#if $file}
-        <PreviewTao bind:QCMs={questions} bind:hideAnswer={$hideAnswer} />
+        <div class="questions-container">
+          {#each renderQuestions as question, i}
+            <QuestionPreview
+              {question}
+              onToggleShow={(show) => (renderQuestions[i].show = show)}
+            />
+          {/each}
+        </div>
       {:else}
         <div class="dropzone-center">
           <EmptyState
@@ -146,6 +169,11 @@
     padding: 16px;
     min-width: 0;
     overflow-x: auto;
+  }
+
+  .questions-container {
+    max-width: 1080px;
+    margin: 0 auto;
   }
 
   .dropzone-center {


### PR DESCRIPTION
The /import route rendered questions with the legacy PreviewTAO component, diverging from /export which uses template/Question.svelte. Adapt the parsed import QCM model into the export QuestionType via a new converter so both routes render questions through the exact same component, keeping them in sync.


Claude-Session: https://claude.ai/code/session_01XQ3Sme7DzfkqbHe416izE7