### PR TITLE
Landing page: futuristic, on-brand motion upgrades

### DIFF
--- a/mono/src/lib/ui/DotCanvas.svelte
+++ b/mono/src/lib/ui/DotCanvas.svelte
@@ -10,9 +10,23 @@
     glow?: number;
     /** Whether the grid reacts to the mouse. */
     interactive?: boolean;
+    /** Draw faint constellation links between active dots near the cursor. */
+    links?: boolean;
+    /** Slow ambient shimmer so the grid breathes even without the mouse. */
+    ambient?: boolean;
+    /** Expanding ripple pulse on click/tap. */
+    ripple?: boolean;
   }
 
-  let { gap = 10, radius = 1, glow = 70, interactive = true }: Props = $props();
+  let {
+    gap = 10,
+    radius = 1,
+    glow = 70,
+    interactive = true,
+    links = true,
+    ambient = true,
+    ripple = true,
+  }: Props = $props();
 
   let canvas: HTMLCanvasElement;
 
@@ -21,12 +35,23 @@
     const mouse = { x: -9999, y: -9999 };
     let raf = 0;
 
+    const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const ambientOn = ambient && !reduce;
+    const rippleOn = ripple && !reduce;
+
+    // Active click ripples: each expands outward then fades.
+    type Ripple = { x: number; y: number; t0: number };
+    let ripples: Ripple[] = [];
+    const RIPPLE_SPEED = 0.45; // px per ms
+    const RIPPLE_LIFE = 900; // ms
+    const RIPPLE_BAND = 60; // px — thickness of the bright ring
+
     function resize() {
       canvas.width = canvas.offsetWidth;
       canvas.height = canvas.offsetHeight;
     }
 
-    function draw() {
+    function draw(now: number) {
       ctx.clearRect(0, 0, canvas.width, canvas.height);
       const isDark = document.documentElement.classList.contains('dark');
       // light: indigo brand | dark: emerald brand — matches --brand token.
@@ -35,14 +60,53 @@
       const cols = Math.ceil(canvas.width / gap) + 1;
       const rows = Math.ceil(canvas.height / gap) + 1;
 
+      // Drop expired ripples.
+      if (rippleOn && ripples.length) {
+        ripples = ripples.filter((rp) => now - rp.t0 < RIPPLE_LIFE);
+      }
+
+      // First pass: compute per-dot intensity so links can reuse it.
+      // intensity = mouse glow + ambient breathing + ripple rings.
+      const intensity = new Float32Array(cols * rows);
+
       for (let row = 0; row < rows; row++) {
         for (let col = 0; col < cols; col++) {
           const x = col * gap;
           const y = row * gap;
-          const dx = x - mouse.x;
-          const dy = y - mouse.y;
-          const dist = Math.sqrt(dx * dx + dy * dy);
-          const t = interactive ? Math.max(0, 1 - dist / glow) : 0;
+
+          let t = 0;
+
+          if (interactive) {
+            const dx = x - mouse.x;
+            const dy = y - mouse.y;
+            const dist = Math.sqrt(dx * dx + dy * dy);
+            t = Math.max(0, 1 - dist / glow);
+          }
+
+          if (ambientOn) {
+            // Diagonal travelling wave — very low amplitude, just "alive".
+            const wave = Math.sin((x + y) * 0.012 - now * 0.0011);
+            t = Math.max(t, 0.16 * (0.5 + 0.5 * wave));
+          }
+
+          if (rippleOn) {
+            for (const rp of ripples) {
+              const age = now - rp.t0;
+              const ringR = age * RIPPLE_SPEED;
+              const dx = x - rp.x;
+              const dy = y - rp.y;
+              const d = Math.sqrt(dx * dx + dy * dy);
+              const band = Math.abs(d - ringR);
+              if (band < RIPPLE_BAND) {
+                const fade = 1 - age / RIPPLE_LIFE;
+                const ring = (1 - band / RIPPLE_BAND) * fade;
+                t = Math.max(t, ring);
+              }
+            }
+          }
+
+          intensity[row * cols + col] = t;
+
           const alpha = 0.1 + t * 0.6;
           const r2 = radius + t * 1.2;
 
@@ -52,13 +116,52 @@
           ctx.fill();
         }
       }
+
+      // Second pass: constellation links between neighbouring lit dots.
+      if (links && interactive) {
+        ctx.lineWidth = 0.6;
+        for (let row = 0; row < rows; row++) {
+          for (let col = 0; col < cols; col++) {
+            const i = row * cols + col;
+            const ti = intensity[i];
+            if (ti < 0.22) continue;
+            const x = col * gap;
+            const y = row * gap;
+
+            // Link to the right and bottom neighbour if it's also lit.
+            if (col + 1 < cols) {
+              const tr = intensity[i + 1];
+              if (tr > 0.22) {
+                const a = Math.min(ti, tr) * 0.5;
+                ctx.strokeStyle = `rgba(${cr},${cg},${cb},${a})`;
+                ctx.beginPath();
+                ctx.moveTo(x, y);
+                ctx.lineTo(x + gap, y);
+                ctx.stroke();
+              }
+            }
+            if (row + 1 < rows) {
+              const tb = intensity[i + cols];
+              if (tb > 0.22) {
+                const a = Math.min(ti, tb) * 0.5;
+                ctx.strokeStyle = `rgba(${cr},${cg},${cb},${a})`;
+                ctx.beginPath();
+                ctx.moveTo(x, y);
+                ctx.lineTo(x, y + gap);
+                ctx.stroke();
+              }
+            }
+          }
+        }
+      }
+
       raf = requestAnimationFrame(draw);
     }
 
     const ro = new ResizeObserver(resize);
     ro.observe(canvas);
     resize();
-    draw();
+    raf = requestAnimationFrame(draw);
 
     const onMouseMove = (e: MouseEvent) => {
       const rect = canvas.getBoundingClientRect();
@@ -66,10 +169,19 @@
       mouse.y = e.clientY - rect.top;
     };
     const onMouseLeave = () => { mouse.x = -9999; mouse.y = -9999; };
+    const onClick = (e: MouseEvent) => {
+      if (!rippleOn) return;
+      const rect = canvas.getBoundingClientRect();
+      ripples.push({ x: e.clientX - rect.left, y: e.clientY - rect.top, t0: performance.now() });
+      if (ripples.length > 6) ripples.shift();
+    };
 
     if (interactive) {
       window.addEventListener('mousemove', onMouseMove);
       canvas.addEventListener('mouseleave', onMouseLeave);
+    }
+    if (rippleOn) {
+      window.addEventListener('pointerdown', onClick);
     }
 
     return () => {
@@ -78,6 +190,9 @@
       if (interactive) {
         window.removeEventListener('mousemove', onMouseMove);
         canvas.removeEventListener('mouseleave', onMouseLeave);
+      }
+      if (rippleOn) {
+        window.removeEventListener('pointerdown', onClick);
       }
     };
   });

--- a/mono/src/routes/+page.svelte
+++ b/mono/src/routes/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import { slide } from 'svelte/transition';
+  import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
   import {
     Bug,
     ChevronDown,
@@ -22,12 +24,28 @@
   const PAGE_DESC =
     'TAO is a unified exam toolkit: import raw data, forge questions, run interactive assessments, and export formatted results — all in one place.';
 
-  // Track the pointer over each card so the spotlight follows the cursor.
+  // Track the pointer over each card: the spotlight follows the cursor, and the
+  // card tilts very slightly toward it for a parallax / depth feel.
+  const MAX_TILT = 6; // degrees
   function onCardMove(e: PointerEvent) {
     const el = e.currentTarget as HTMLElement;
     const rect = el.getBoundingClientRect();
-    el.style.setProperty('--mx', `${e.clientX - rect.left}px`);
-    el.style.setProperty('--my', `${e.clientY - rect.top}px`);
+    const px = e.clientX - rect.left;
+    const py = e.clientY - rect.top;
+    el.style.setProperty('--mx', `${px}px`);
+    el.style.setProperty('--my', `${py}px`);
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+    // Normalise to -0.5..0.5 around the card centre.
+    const nx = px / rect.width - 0.5;
+    const ny = py / rect.height - 0.5;
+    el.style.setProperty('--ry', `${nx * MAX_TILT * 2}deg`);
+    el.style.setProperty('--rx', `${-ny * MAX_TILT * 2}deg`);
+  }
+
+  function onCardLeave(e: PointerEvent) {
+    const el = e.currentTarget as HTMLElement;
+    el.style.setProperty('--rx', '0deg');
+    el.style.setProperty('--ry', '0deg');
   }
 
   interface Route {
@@ -68,6 +86,25 @@
       available: true,
     },
   ];
+
+  // Number keys 1–4 launch the matching module — a small command-palette touch.
+  onMount(() => {
+    function onKey(e: KeyboardEvent) {
+      // Ignore when typing in a field or using modifier combos.
+      const target = e.target as HTMLElement | null;
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      if (target && /^(INPUT|TEXTAREA|SELECT)$/.test(target.tagName)) return;
+      const n = Number(e.key);
+      if (!Number.isInteger(n) || n < 1 || n > routes.length) return;
+      const route = routes[n - 1];
+      if (route?.available) {
+        e.preventDefault();
+        goto(route.path);
+      }
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  });
 </script>
 
 <svelte:head>
@@ -135,9 +172,17 @@
           <path d="M16 8.5 L22.5 19.5 L9.5 19.5 Z" stroke="currentColor" stroke-width="1.2" opacity="0.5" />
         </svg>
       </span>
-      <h1 class="wordmark">TAO</h1>
+      <h1 class="wordmark" data-text="TAO">TAO</h1>
     </div>
     <p class="subtitle">Exams, end to end — import, forge, run and export, all in one place.</p>
+    <div class="meta-readout" aria-hidden="true">
+      <span class="status-dot"></span>
+      <span class="meta-item">operational</span>
+      <span class="meta-sep">·</span>
+      <span class="meta-item">{routes.length} modules</span>
+      <span class="meta-sep">·</span>
+      <span class="meta-item">press <kbd>1</kbd>–<kbd>{routes.length}</kbd> to launch</span>
+    </div>
   </header>
 
   <nav class="route-grid">
@@ -150,10 +195,14 @@
         tabindex={route.available ? 0 : -1}
         style="--delay:{i * 70}ms;"
         onpointermove={onCardMove}
+        onpointerleave={onCardLeave}
       >
         <span class="route-icon">
           <route.icon size={20} strokeWidth={1.75} />
         </span>
+        {#if route.available}
+          <kbd class="route-key" aria-hidden="true">{i + 1}</kbd>
+        {/if}
         <div class="route-body">
           <h2 class="route-title">{route.title}</h2>
           <p class="route-description">{route.description}</p>
@@ -242,12 +291,39 @@
   }
 
   .wordmark {
+    position: relative;
     margin: 0;
     font-size: clamp(2.75rem, 9vw, 4rem);
     font-weight: 700;
     letter-spacing: -0.045em;
     line-height: 1;
     color: var(--text);
+  }
+
+  /* One-shot brand light sweep across the letters on load. */
+  .wordmark::after {
+    content: attr(data-text);
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+      100deg,
+      transparent 38%,
+      rgba(var(--brand-rgb), 0.95) 50%,
+      transparent 62%
+    );
+    background-size: 250% 100%;
+    background-position: 120% 0;
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    color: transparent;
+    pointer-events: none;
+    animation: sheen 1.5s cubic-bezier(0.22, 1, 0.36, 1) 0.4s both;
+  }
+
+  @keyframes sheen {
+    from { background-position: 120% 0; }
+    to   { background-position: -60% 0; }
   }
 
   .subtitle {
@@ -258,6 +334,52 @@
     margin: 1.1rem auto 0;
   }
 
+  /* ── Tech meta readout ────────────────────────────────── */
+  .meta-readout {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-top: 1.1rem;
+    padding: 0.3rem 0.7rem;
+    border: 1px solid var(--border);
+    border-radius: 9999px;
+    background: var(--surface);
+    font-family: 'SF Mono', 'Roboto Mono', ui-monospace, monospace;
+    font-size: 0.7rem;
+    letter-spacing: 0.04em;
+    color: var(--text-muted);
+    text-transform: uppercase;
+  }
+
+  .status-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--brand);
+    box-shadow: 0 0 0 0 rgba(var(--brand-rgb), 0.55);
+    animation: pulse 2.4s ease-out infinite;
+  }
+
+  @keyframes pulse {
+    0%   { box-shadow: 0 0 0 0 rgba(var(--brand-rgb), 0.5); }
+    70%  { box-shadow: 0 0 0 6px rgba(var(--brand-rgb), 0); }
+    100% { box-shadow: 0 0 0 0 rgba(var(--brand-rgb), 0); }
+  }
+
+  .meta-sep {
+    opacity: 0.5;
+  }
+
+  .meta-readout kbd {
+    font-family: inherit;
+    font-size: 0.65rem;
+    padding: 0.05rem 0.3rem;
+    border: 1px solid var(--border-strong);
+    border-radius: 4px;
+    color: var(--text);
+    background: var(--surface-elevated);
+  }
+
   /* ── Route grid ───────────────────────────────────────── */
   .route-grid {
     display: grid;
@@ -265,9 +387,13 @@
     gap: 1rem;
     width: 100%;
     max-width: 1280px;
+    perspective: 1200px;
   }
 
   .route-card {
+    --rx: 0deg;
+    --ry: 0deg;
+    --lift: 0px;
     position: relative;
     display: flex;
     flex-direction: column;
@@ -281,9 +407,50 @@
     color: var(--text);
     overflow: hidden;
     isolation: isolate;
-    transition: box-shadow 0.25s ease, border-color 0.25s ease, transform 0.25s ease;
+    transform-style: preserve-3d;
+    transform: rotateX(var(--rx)) rotateY(var(--ry)) translateY(var(--lift));
+    transition: box-shadow 0.25s ease, border-color 0.25s ease, transform 0.18s ease;
     animation: rise 0.55s cubic-bezier(0.22, 1, 0.36, 1) both;
     animation-delay: var(--delay);
+  }
+
+  /* Single-accent border-beam that sweeps the hairline on hover. */
+  @property --beam {
+    syntax: '<angle>';
+    initial-value: 0deg;
+    inherits: false;
+  }
+
+  .route-card::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    padding: 1px;
+    background: conic-gradient(
+      from var(--beam),
+      transparent 0deg,
+      rgba(var(--brand-rgb), 0.75) 38deg,
+      transparent 110deg
+    );
+    -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+    -webkit-mask-composite: xor;
+    mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+    mask-composite: exclude;
+    opacity: 0;
+    transition: opacity 0.25s ease;
+    pointer-events: none;
+    z-index: 1;
+  }
+
+  .route-card:not(.unavailable):hover::before,
+  .route-card:not(.unavailable):focus-visible::before {
+    opacity: 1;
+    animation: beam 2.6s linear infinite;
+  }
+
+  @keyframes beam {
+    to { --beam: 360deg; }
   }
 
   /* subtle brand-tinted spotlight that follows the cursor */
@@ -304,9 +471,9 @@
   }
 
   .route-card:not(.unavailable):hover {
+    --lift: -3px;
     border-color: rgba(var(--brand-rgb), 0.45);
     box-shadow: var(--shadow-lg);
-    transform: translateY(-3px);
   }
 
   .route-card:not(.unavailable):hover::after,
@@ -339,6 +506,7 @@
     color: var(--text-muted);
     background: var(--surface);
     border: 1px solid var(--border);
+    transform: translateZ(38px);
     transition: color 0.25s ease, background 0.25s ease, border-color 0.25s ease;
   }
 
@@ -354,6 +522,7 @@
     display: flex;
     flex-direction: column;
     gap: 0.35rem;
+    transform: translateZ(20px);
   }
 
   .route-title {
@@ -370,6 +539,33 @@
     line-height: 1.55;
   }
 
+  .route-key {
+    position: absolute;
+    top: 1.25rem;
+    right: 1.25rem;
+    z-index: 2;
+    display: grid;
+    place-items: center;
+    min-width: 1.25rem;
+    height: 1.25rem;
+    padding: 0 0.3rem;
+    font-family: 'SF Mono', 'Roboto Mono', ui-monospace, monospace;
+    font-size: 0.7rem;
+    line-height: 1;
+    color: var(--text-muted);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 5px;
+    transform: translateZ(28px);
+    opacity: 0.55;
+    transition: opacity 0.2s ease;
+  }
+
+  .route-card:not(.unavailable):hover .route-key,
+  .route-card:not(.unavailable):focus-visible .route-key {
+    opacity: 0;
+  }
+
   .route-card :global(.route-arrow) {
     position: absolute;
     top: 1.4rem;
@@ -377,13 +573,13 @@
     z-index: 2;
     color: var(--text-muted);
     opacity: 0;
-    transform: translate(-4px, 4px);
+    transform: translate(-4px, 4px) translateZ(28px);
     transition: opacity 0.25s ease, transform 0.25s ease, color 0.25s ease;
   }
 
   .route-card:not(.unavailable):hover :global(.route-arrow) {
     opacity: 1;
-    transform: translate(0, 0);
+    transform: translate(0, 0) translateZ(28px);
     color: var(--brand);
   }
 
@@ -450,6 +646,12 @@
     .hero,
     .route-card,
     .debug-section { animation: none !important; opacity: 1; }
-    .route-card { transition: box-shadow 0.2s ease, border-color 0.2s ease; }
+    .route-card {
+      transform: none !important;
+      transition: box-shadow 0.2s ease, border-color 0.2s ease;
+    }
+    .route-card::before { animation: none !important; }
+    .wordmark::after { animation: none !important; opacity: 0; }
+    .status-dot { animation: none !important; }
   }
 </style>


### PR DESCRIPTION
Make the homepage feel more alive and "tech" while keeping the restrained, premium TAO design language (single brand accent, no rainbow, neutral surfaces):

- DotCanvas: faint constellation mesh between active dots near the cursor, slow ambient "breathing" wave, and an expanding click ripple. New opt-in props (links/ambient/ripple); all motion respects prefers-reduced-motion.
- Route cards: subtle 3D parallax tilt toward the cursor with depth-lifted icon/title, plus a single-accent border-beam that sweeps the hairline on hover (masked conic gradient via @property).
- Wordmark: one-shot brand light-sweep on load.
- Hero: monospace "control panel" meta readout (pulsing operational dot, module count, launch hint).
- Keyboard launch: number keys 1-4 open the matching module, with faint kbd chips on each card.

All new animation is disabled under prefers-reduced-motion.


Claude-Session: https://claude.ai/code/session_011hM491o8qDfjtknv2gJg35