### PR TITLE
Refactor assessment model and adapters for standardized format

### DIFF
--- a/mono/src/lib/export/Settings.svelte
+++ b/mono/src/lib/export/Settings.svelte
@@ -15,10 +15,11 @@
     randomizeAnswer,
     randomizeQuestion,
     darkMode,
-    questions,
+    activeItems,
+    showItems,
   } from "./store";
   import { slide } from "svelte/transition";
-  import type { QuestionType } from "./helper";
+  import type { AssessmentItem } from "$lib/questions/types.js";
   import {
     Eye,
     EyeOff,
@@ -91,41 +92,44 @@
   let questionListContainer: HTMLUListElement | null = $state(null);
   let itemDraggingIndex = $state(-1);
   let itemHoveredIndex = $state(-1);
-  let itemDragged: QuestionType | null = $state(null);
+  let itemDragged: AssessmentItem | null = $state(null);
   let mouseYCoordinate = $state(-1);
   let distanceTopGrabbedVsPointer = $state(-1);
 
   $effect.pre(() => {
     if (questionListText) {
       const qn = questionListText.split(",").map((n: string) => n.trim());
-      questions.update((o) =>
-        o.map((q) => ({
-          ...q,
-          show: qn.includes(q.title.split(" ")[1]),
-        })),
-      );
+      showItems.update(m => {
+        const updated = new Map(m);
+        for (const item of $activeItems) {
+          updated.set(item.id, qn.includes(item.title.split(" ")[1]));
+        }
+        return updated;
+      });
     }
   });
 
   function changeQuestionSelection() {
-    questions.update((o) =>
-      o.map((q) => ({ ...q, show: questionListChecked })),
-    );
+    showItems.update(m => {
+      const updated = new Map(m);
+      for (const item of $activeItems) {
+        updated.set(item.id, questionListChecked);
+      }
+      return updated;
+    });
   }
 
-  function toggleQuestion(index: number, value: boolean) {
-    questions.update((o) =>
-      o.map((q, i) => (i === index ? { ...q, show: value } : q)),
-    );
+  function toggleQuestion(itemId: string, value: boolean) {
+    showItems.update(m => { const u = new Map(m); u.set(itemId, value); return u; });
   }
 
   function onDragStart(
     e: DragEvent & { currentTarget: EventTarget & HTMLDivElement },
     i: number,
-    question: QuestionType,
+    item: AssessmentItem,
   ) {
     mouseYCoordinate = e.clientY;
-    itemDragged = question;
+    itemDragged = item;
     itemDraggingIndex = i;
     distanceTopGrabbedVsPointer =
       e.currentTarget.getBoundingClientRect().y - e.clientY;
@@ -137,7 +141,7 @@
       itemHoveredIndex != -1 &&
       itemDraggingIndex != itemHoveredIndex
     ) {
-      questions.update((list) => {
+      activeItems.update((list) => {
         [list[itemDraggingIndex], list[itemHoveredIndex]] = [
           list[itemHoveredIndex],
           list[itemDraggingIndex],
@@ -291,7 +295,7 @@
   </div>
 
   <!-- Question Filtering Section -->
-  {#if $questions && $questions.length}
+  {#if $activeItems && $activeItems.length}
     <div class="settings-section">
       <button
         class="section-header"
@@ -328,14 +332,14 @@
           </div>
 
           <ul class="question-list-items" bind:this={questionListContainer}>
-            {#each $questions as question, i (question.title + i)}
+            {#each $activeItems as item, i (item.id + i)}
               <li ondragover={(e) => e.preventDefault()}>
                 <label class="checkbox-label">
                   <input
                     type="checkbox"
-                    id="{question.title}-{i}"
-                    checked={question.show}
-                    onchange={(e) => toggleQuestion(i, e.currentTarget.checked)}
+                    id="{item.id}-{i}"
+                    checked={$showItems.get(item.id) !== false}
+                    onchange={(e) => toggleQuestion(item.id, e.currentTarget.checked)}
                   />
                 </label>
                 <div
@@ -343,13 +347,13 @@
                   role="button"
                   tabindex="0"
                   draggable="true"
-                  ondragstart={(e) => onDragStart(e, i, question)}
+                  ondragstart={(e) => onDragStart(e, i, item)}
                   ondragover={() => (itemHoveredIndex = i)}
                 >
                   <GripVertical size={16} />
                 </div>
-                <label for="{question.title}-{i}" class="question-title"
-                  >{question.title}</label
+                <label for="{item.id}-{i}" class="question-title"
+                  >{item.title}</label
                 >
               </li>
             {/each}

--- a/mono/src/lib/export/Settings.svelte
+++ b/mono/src/lib/export/Settings.svelte
@@ -178,6 +178,27 @@
           </span>
           <Switch bind:checked={$showInstruction} />
         </div>
+        {#if !$showInstruction}
+          {@const instructions = $activeItems.filter(i => i.type === 'instruction')}
+          {#if instructions.length}
+            <ul class="instruction-overrides">
+              {#each instructions as item (item.id)}
+                <li>
+                  <label class="checkbox-label">
+                    <input
+                      type="checkbox"
+                      checked={$showItems.get(item.id) === true}
+                      onchange={(e) => {
+                        showItems.update(m => { const u = new Map(m); u.set(item.id, e.currentTarget.checked); return u; });
+                      }}
+                    />
+                    <span>{item.title || item.label || item.id}</span>
+                  </label>
+                </li>
+              {/each}
+            </ul>
+          {/if}
+        {/if}
         <div class="setting-row">
           <span class="setting-label">
             <List size={14} />
@@ -541,6 +562,22 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  .instruction-overrides {
+    list-style: none;
+    margin: 4px 0 8px;
+    padding: 6px 8px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .instruction-overrides li {
+    display: flex;
   }
 
   .checkbox-label {

--- a/mono/src/lib/export/Tables.svelte
+++ b/mono/src/lib/export/Tables.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { questions } from "./store";
+  import { activeItems, showItems, showInstruction } from "./store";
   import { FileText, Grid } from 'lucide-svelte';
 
   let checked = true;
@@ -8,32 +8,41 @@
   $effect.pre(() => {
     if (text) {
       const qn = text.split(",").map((n) => n.trim());
-      questions.update((o) =>
-        o.map((q) => ({
-          ...q,
-          show: qn.includes(q.title.split(" ")[1]),
-        })),
-      );
+      showItems.update(m => {
+        const updated = new Map(m);
+        for (const item of $activeItems) {
+          const num = item.title.split(" ")[1];
+          updated.set(item.id, qn.includes(num));
+        }
+        return updated;
+      });
     }
   });
 
-  let container = null;
+  const qoCount = $derived($activeItems.filter(i => i.type === 'text').length);
+  const qcmCount = $derived($activeItems.filter(i => i.type === 'single-choice').length);
+  const qoVisible = $derived(
+    $activeItems.filter(i => i.type === 'text' && $showItems.get(i.id) !== false).length
+  );
+  const qcmVisible = $derived(
+    $activeItems.filter(i => i.type === 'single-choice' && $showItems.get(i.id) !== false).length
+  );
 </script>
 
-    <div class="nb-questions">
-      <span class="stat qo">
-        <FileText size={14} />
-        <span class="stat-value">{$questions.filter((q) => q.type === "QO").length}</span>
-        <span class="stat-label">QO</span>
-        <span class="stat-count">({$questions.filter((q) => q.type === "Instruction QO" && q.show).length})</span>
-      </span>
-      <span class="stat qcm">
-        <Grid size={14} />
-        <span class="stat-value">{$questions.filter((q) => q.type === "QCM").length}</span>
-        <span class="stat-label">QCM</span>
-        <span class="stat-count">({$questions.filter((q) => q.type === "QCM" && q.show).length})</span>
-      </span>
-    </div>
+<div class="nb-questions">
+  <span class="stat qo">
+    <FileText size={14} />
+    <span class="stat-value">{qoCount}</span>
+    <span class="stat-label">QO</span>
+    <span class="stat-count">({qoVisible})</span>
+  </span>
+  <span class="stat qcm">
+    <Grid size={14} />
+    <span class="stat-value">{qcmCount}</span>
+    <span class="stat-label">QCM</span>
+    <span class="stat-count">({qcmVisible})</span>
+  </span>
+</div>
 
 <style>
   .nb-questions {

--- a/mono/src/lib/export/ZipDropZone.svelte
+++ b/mono/src/lib/export/ZipDropZone.svelte
@@ -14,19 +14,23 @@
   import { get } from "svelte/store";
 
   let files = $state<File[]>([]);
+  let loadError = $state<string | null>(null);
+  let loading = $state(false);
 
   $effect(() => {
     const f = Array.from(files);
     if (!f.length) return;
 
     sourceFileName.set(f.map((file) => file.name).join(", "));
+    loadError = null;
+    loading = true;
 
     const adapter = new QtiAdapter();
 
     Promise.all(
       f.map(async (file) => {
         if (!file.name.toLowerCase().endsWith(".zip")) {
-          throw new Error("Please select a zip file");
+          throw new Error(`"${file.name}" is not a .zip file`);
         }
         return adapter.read(file);
       })
@@ -38,8 +42,16 @@
         activeItems.set(active.sections.flatMap(s => s.items));
         windowName.set(active.title || "TAO-Export" + Math.floor(Math.random() * 1000));
       }
+      const total = data.reduce((n, a) => n + a.sections.reduce((m, s) => m + s.items.length, 0), 0);
+      if (total === 0) {
+        loadError = "The ZIP was read, but no questions were found inside it.";
+      }
     }).catch((e) => {
-      pushError("ZIP Load Error", String(e?.message ?? e));
+      const msg = String(e?.message ?? e);
+      loadError = msg;
+      pushError("ZIP Load Error", msg);
+    }).finally(() => {
+      loading = false;
     });
 
     resetSettings();
@@ -47,3 +59,30 @@
 </script>
 
 <FileInput bind:file={files} accept=".zip" multiple={$multiple} />
+
+{#if loading}
+  <p class="dz-status">Reading ZIP…</p>
+{/if}
+{#if loadError}
+  <p class="dz-error">{loadError}</p>
+{/if}
+
+<style>
+  .dz-status {
+    margin: 12px 0 0;
+    font-size: 13px;
+    color: var(--text-muted);
+    text-align: center;
+  }
+
+  .dz-error {
+    margin: 12px 0 0;
+    padding: 8px 12px;
+    font-size: 13px;
+    color: var(--danger, #dc2626);
+    background: rgba(220, 38, 38, 0.08);
+    border: 1px solid rgba(220, 38, 38, 0.3);
+    border-radius: var(--radius);
+    text-align: center;
+  }
+</style>

--- a/mono/src/lib/export/ZipDropZone.svelte
+++ b/mono/src/lib/export/ZipDropZone.svelte
@@ -1,26 +1,18 @@
 <script lang="ts">
-  import { ZipReader } from "@zip.js/zip.js";
-
+  import { QtiAdapter } from "$lib/questions/adapters/qti.js";
   import {
-    entryToObj,
-    readAndParseXml,
-    xmlToObj,
-    type EntryObj,
-    type QuestionType,
-  } from "./helper";
-  import {
-    exams,
+    assessments,
     examsIndex,
     multiple,
-    questions,
+    activeItems,
     resetSettings,
     windowName,
     sourceFileName,
+    pushError,
   } from "./store";
   import FileInput from "$lib/ui/FileInput.svelte";
   import { get } from "svelte/store";
 
-  let assets: EntryObj[];
   let files = $state<File[]>([]);
 
   $effect(() => {
@@ -29,59 +21,27 @@
 
     sourceFileName.set(f.map((file) => file.name).join(", "));
 
+    const adapter = new QtiAdapter();
+
     Promise.all(
       f.map(async (file) => {
-        if (file.name.split(".").pop() !== "zip")
+        if (!file.name.toLowerCase().endsWith(".zip")) {
           throw new Error("Please select a zip file");
-
-        try {
-          const zipReader = new ZipReader(file.stream());
-          const entries = await zipReader.getEntries();
-
-          assets = entries
-            .filter(
-              (entry) =>
-                !entry.filename.toLowerCase().endsWith(".css") &&
-                !entry.filename.toLowerCase().endsWith(".xml"),
-            )
-            .map(entryToObj);
-
-          const xmls = await Promise.all(
-            entries
-              .filter(
-                (entry) =>
-                  entry.filename.toLowerCase().endsWith(".xml") &&
-                  entry.filename.toLowerCase() !== "imsmanifest.xml",
-              )
-              .map(entryToObj)
-              .map((obj) => readAndParseXml(obj, assets)),
-          );
-
-          const name = file.name.replace("_", " ").split("-")[0].toUpperCase();
-
-          return {
-            questions: xmls.map(xmlToObj).filter((q) => q),
-            error: null,
-            name,
-          };
-        } catch (e) {
-          return {
-            questions: [] as QuestionType[],
-            error: e as Error,
-            name: "",
-          };
         }
-      }),
+        return adapter.read(file);
+      })
     ).then((data) => {
-      exams.set(data);
-      const q = data[get(examsIndex)];
-      if (q && q.questions && q.questions.length) {
-        questions.set(q.questions);
-        windowName.set(
-          q.name || "TAO-Export" + Math.floor(Math.random() * 1000),
-        );
+      assessments.set(data);
+      const index = get(examsIndex);
+      const active = data[index] ?? data[0];
+      if (active) {
+        activeItems.set(active.sections.flatMap(s => s.items));
+        windowName.set(active.title || "TAO-Export" + Math.floor(Math.random() * 1000));
       }
+    }).catch((e) => {
+      pushError("ZIP Load Error", String(e?.message ?? e));
     });
+
     resetSettings();
   });
 </script>

--- a/mono/src/lib/export/ZipInput.svelte
+++ b/mono/src/lib/export/ZipInput.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import {
-    exams,
+    assessments,
     resetQuestions,
     windowName,
     sourceFileName,
@@ -22,7 +22,7 @@
 
   // Clearing the file sends the user back to the centered drop zone in the main area.
   function clearFile() {
-    exams.set([]);
+    assessments.set([]);
     resetQuestions();
     windowName.set("TAO Export");
     sourceFileName.set("");
@@ -40,7 +40,7 @@
     </div>
   {/if}
 
-  {#if $exams.length > 0}
+  {#if $assessments.length > 0}
     <Button
       onclick={() => {
         if (exportFormat === 'pdf') {

--- a/mono/src/lib/export/audit/AuditTab.svelte
+++ b/mono/src/lib/export/audit/AuditTab.svelte
@@ -7,7 +7,7 @@
   import AuditConfig from "./AuditConfig.svelte";
   import AuditResults from "./AuditResults.svelte";
   import {
-    questions,
+    activeItems,
     auditReport,
     auditLoading,
     auditError,
@@ -41,56 +41,27 @@
       .trim();
   }
 
-  function convertQTIQuestions(qtiQuestions: any[]): QTIQuestion[] {
-    return qtiQuestions
-      .filter((q) => {
-        if (q.type === "Instruction" || q.type === "Instruction QCM")
-          return false;
-        return true;
-      })
-      .map((q) => {
-        let promptText = "";
-
-        if (q.prompt) {
-          if (typeof q.prompt === "string") {
-            promptText = stripHtmlTags(q.prompt);
-          } else if (Array.isArray(q.prompt)) {
-            promptText = q.prompt
-              .map((el: any) => {
-                if (el && typeof el === "object" && "textContent" in el) {
-                  return (el as Element).textContent || "";
-                } else if (el && typeof el === "object" && "outerHTML" in el) {
-                  return stripHtmlTags((el as Element).outerHTML);
-                }
-                return String(el || "");
-              })
-              .join(" ")
-              .trim();
-          }
-        }
-
-        if (!promptText) {
-          promptText = stripHtmlTags(q.text || q.content || "");
-        }
-
+  function convertQTIQuestions(items: typeof $activeItems): QTIQuestion[] {
+    return items
+      .filter(item => item.type !== 'instruction')
+      .map(item => {
+        const promptText = stripHtmlTags(item.content.html ?? item.content.text ?? '');
+        const options = item.responses?.[0]?.options ?? [];
         return {
-          id: q.id || q.title || "",
-          title: q.title,
+          id: item.id,
+          title: item.title,
           prompt: promptText,
-          answers: (q.answers || []).map((a: any) => ({
-            text: stripHtmlTags(a.text || a.txt || a.content || ""),
-            correct: a.correct === true || a.correct === "true",
-            id: a.id,
+          answers: options.map(opt => ({
+            text: stripHtmlTags(opt.content.html ?? opt.content.text ?? ''),
+            correct: opt.correct === true,
+            id: opt.id,
           })),
-          type: q.type,
-          points: q.points,
-          metadata: {
-            qtiId: q.id,
-            originalType: q.type,
-          },
+          type: (item.type === 'single-choice' ? 'QCM' : item.type === 'text' ? 'QO' : undefined) as 'QCM' | 'QO' | undefined,
+          points: item.scoring?.maxScore,
+          metadata: { qtiId: item.id, originalType: item.type },
         };
       })
-      .filter((q) => q.prompt && q.prompt.length > 0);
+      .filter(q => q.prompt && q.prompt.length > 0);
   }
 
   async function handleRunAudit() {
@@ -110,7 +81,7 @@
 
     try {
       const buffer = await excelFile.arrayBuffer();
-      const qtiQs = convertQTIQuestions($questions);
+      const qtiQs = convertQTIQuestions($activeItems);
 
       if (qtiQs.length === 0) {
         auditError.set(
@@ -178,7 +149,7 @@
     };
   });
 
-  const hasQuestions = $questions && $questions.length > 0;
+  const hasQuestions = $activeItems && $activeItems.length > 0;
 </script>
 
 <div class="audit-container">
@@ -316,7 +287,7 @@
                 <div class="summary-grid">
                   <div class="summary-item">
                     <span class="summary-label">QTI Questions:</span>
-                    <span class="summary-value">{$questions.length}</span>
+                    <span class="summary-value">{$activeItems.length}</span>
                   </div>
                   <div class="summary-item">
                     <span class="summary-label">Excel Start Row:</span>

--- a/mono/src/lib/export/helper.ts
+++ b/mono/src/lib/export/helper.ts
@@ -92,9 +92,9 @@ export type QuestionType = {
   | 'Instruction QCM'
   | 'Instruction QO'
   | 'unknown';
-  prompt: Element[];
+  prompt: string;
   answers: { txt: string; point: string; id: string; correct: boolean }[];
-  maxLenght?: string[];
+  maxLenght?: string;
   show: boolean
 };
 
@@ -103,7 +103,7 @@ export const xmlToObj = (xml: EntryObj): QuestionType => {
     return {
       title: 'unknown',
       type: 'unknown',
-      prompt: [],
+      prompt: '',
       answers: [],
       show: false
     };
@@ -134,22 +134,22 @@ export const xmlToObj = (xml: EntryObj): QuestionType => {
     return {
       title,
       type: 'Instruction',
-      prompt: Array.from(xDoc.getElementsByClassName('grid-row')),
+      prompt: Array.from(xDoc.getElementsByClassName('grid-row')).map(el => el.outerHTML).join(''),
       answers: [],
       show: true
     };
   }
 
   let answers: QuestionType['answers'] = [];
-  let prompt: HTMLCollectionOf<Element> | Element[];
+  let promptHtml = '';
   let type;
-  let maxLenght: string[] = [];
+  let maxLenght: string | undefined;
 
   const inner = Array.from(xDoc.getElementsByTagName('itemBody'))[0];
 
   if (Instructie) {
-    prompt = Array.from(xDoc.getElementsByTagName('assessmentTest'));
     type = 'Instruction';
+    promptHtml = '';
   } else if (QO) {
     if (
       ['Voorbeeld', 'Exemple'].find((t) =>
@@ -160,28 +160,13 @@ export const xmlToObj = (xml: EntryObj): QuestionType => {
     } else {
       type = 'QO';
     }
-    prompt = inner.getElementsByClassName('grid-row');
-    const maxLenghtTemp = Array
-      .from(xDoc.getElementsByTagName('extendedTextInteraction'))
-      .map(i => i.getAttribute('patternMask'))
-      .map(i => {
-        try {
-          if (i === null) return '∞';
-          return i.split(',')[1].split('}')[0];
-        } catch (e) {
-          return '∞';
-        }
-      });
-    maxLenght = [];
-    for (let index = 0; index < prompt.length; index++) {
-      const p = prompt.item(index);
-      const extendedTextInteraction = p?.getElementsByTagName('extendedTextInteraction') || [];
-
-      if (extendedTextInteraction.length > 0) {
-        maxLenght.push(maxLenghtTemp.shift() || '');
-      }
-      else {
-        maxLenght.push('');
+    promptHtml = Array.from(inner.getElementsByClassName('grid-row')).map(el => el.outerHTML).join('');
+    const firstMask = xDoc.getElementsByTagName('extendedTextInteraction')[0]?.getAttribute('patternMask');
+    if (firstMask) {
+      try {
+        maxLenght = firstMask.split(',')[1].split('}')[0];
+      } catch (_) {
+        maxLenght = '∞';
       }
     }
   } else {
@@ -195,14 +180,13 @@ export const xmlToObj = (xml: EntryObj): QuestionType => {
       type = 'QCM';
     }
 
-    prompt = Array.from(inner.getElementsByClassName('grid-row')).filter(
+    const promptRows = Array.from(inner.getElementsByClassName('grid-row')).filter(
       (d) => d.getElementsByTagName('simpleChoice').length === 0
     );
-
-    prompt = prompt.concat(Array.from(inner.getElementsByTagName('prompt')));
+    const promptEls = Array.from(inner.getElementsByTagName('prompt'));
+    promptHtml = [...promptRows, ...promptEls].map(el => el.outerHTML).join('');
 
     // Get correct answer mapping
-
     const answerMapping = Array.from(
       xDoc.getElementsByTagName('mapping')[0].children
     ).map((child) => ({
@@ -224,14 +208,10 @@ export const xmlToObj = (xml: EntryObj): QuestionType => {
     );
   }
 
-  const normalizedPrompt: Element[] = Array.isArray(prompt) 
-    ? prompt as Element[] 
-    : Array.from((prompt as any) || []);
-
   return {
     title,
     type: type as QuestionType['type'],
-    prompt: normalizedPrompt,
+    prompt: promptHtml,
     answers,
     maxLenght,
     show: true

--- a/mono/src/lib/export/store.ts
+++ b/mono/src/lib/export/store.ts
@@ -1,72 +1,69 @@
-import { writable, derived, get, } from "svelte/store";
-import type { QuestionType } from "$lib/export/helper";
+import { writable, derived, get } from "svelte/store";
+import type { Assessment, AssessmentItem } from "$lib/questions/types.js";
 
 export let errors = writable<{ title: string, txt: string, visible: boolean }[]>([]);
 
 export const pushError = (title: string, txt: string) => {
   const obj = { txt, title, visible: true };
   errors.update(errors => [...errors, obj]);
-  // remove error after 5 seconds
   setTimeout(() => {
     errors.update(errors => errors.filter(err => err !== obj));
   }, 5000);
 }
 
-// Assesments
-export let exams = writable<{ questions: QuestionType[], error: null | Error, name: string }[]>([])
-export let questions = writable<QuestionType[]>([]);
-export let oldQuestions = writable<QuestionType[]>([]);
+// Assessments
+export let assessments = writable<Assessment[]>([]);
+export let activeItems = writable<AssessmentItem[]>([]);
+export let oldItems = writable<AssessmentItem[]>([]);
 export let examsIndex = writable<number>(0);
-export let windowName = writable<string>("TAO Export")
-// Name of the loaded source zip file(s), shown in the sidebar.
+export let windowName = writable<string>("TAO Export");
 export const sourceFileName = writable<string>("");
 
+// Per-item visibility overrides (false = hidden by user, undefined/absent = visible)
+export const showItems = writable<Map<string, boolean>>(new Map());
+
 examsIndex.subscribe((index) => {
-  const ex = get(exams)
-  if (!ex) return
-  if (index > ex.length) {
-    index = (ex.length % index) - 1
-  }
-  const q = ex[index]
-  if (!q) return
-
-  questions.set(q.questions)
-  originalQuestionOrder = [];
-  originalQuestionIndices = new Map();
+  const list = get(assessments);
+  if (!list || index >= list.length) return;
+  const assessment = list[index];
+  if (!assessment) return;
+  const items = assessment.sections.flatMap(s => s.items);
+  activeItems.set(items);
+  oldItems.set([]);
+  showItems.set(new Map());
+  originalItemOrder = [];
+  originalItemIndices = new Map();
   originalAnswerOrders = new Map();
-  windowName.set(q.name || "TAO-Export" + Math.floor(Math.random() * 1000))
-})
+  windowName.set(assessment.title || "TAO-Export" + Math.floor(Math.random() * 1000));
+});
 
-// Assesments action
+// Actions
 
 export const resetQuestions = () => {
-  questions.set([]);
-  oldQuestions.set([]);
-}
+  activeItems.set([]);
+  oldItems.set([]);
+  showItems.set(new Map());
+};
 
 export const copyQuestion = () => {
-  oldQuestions.set(get(questions));
-}
-
+  oldItems.set(get(activeItems));
+};
 
 export const sortQuestions = () => {
   copyQuestion();
-  questions.update(() =>
-    get(questions).sort((a, b) => {
-      if (a.type.includes('Instruction') || a.type === 'Instruction QCM')
-        return 1;
-      // sort by number find after QO and QCM
+  activeItems.update(items =>
+    [...items].sort((a, b) => {
+      if (a.type === 'instruction') return 1;
+      if (b.type === 'instruction') return -1;
       const aNumber = a.title.match(/\d+/);
       const bNumber = b.title.match(/\d+/);
-      if (aNumber && bNumber) {
-        return Number(aNumber[0]) - Number(bNumber[0]);
-      }
+      if (aNumber && bNumber) return Number(aNumber[0]) - Number(bNumber[0]);
       return 0;
     })
   );
-}
+};
 
-// Menu
+// Sidebar re-export
 export { sidebarOpen as showMenu } from '$lib/sidebar';
 
 // Settings
@@ -79,22 +76,20 @@ export const compareMode = writable(false);
 export const compareExamIndex1 = writable<number>(-1);
 export const compareExamIndex2 = writable<number>(-1);
 export const zoom = writable(1);
-export const multiple = writable(false)
-export const merge = writable(false)
-export const darkMode = writable(false)
+export const multiple = writable(false);
+export const merge = writable(false);
+export const darkMode = writable(false);
 
 // ============================================================================
-// AUDIT STORES - Declared early because used in subscriber functions below
+// AUDIT STORES
 // ============================================================================
 
 import type { AuditReport, ExcelConfig } from '$lib/export/audit/types';
 import { DEFAULT_CONFIG } from '$lib/export/audit/config';
 
-// Navigation
 export type PageType = 'questions' | 'audit' | 'compare';
 export const currentPage = writable<PageType>('questions');
 
-// Audit UI state (deprecated: use currentPage instead)
 export const auditTab = writable<boolean>(false);
 export const auditLoading = writable<boolean>(false);
 export const auditReport = writable<AuditReport | null>(null);
@@ -102,7 +97,6 @@ export const auditConfig = writable<ExcelConfig>(DEFAULT_CONFIG);
 export const auditFilename = writable<string>('');
 export const auditError = writable<string | null>(null);
 
-// Reset audit state
 export const resetAudit = () => {
   auditLoading.set(false);
   auditReport.set(null);
@@ -115,9 +109,8 @@ export const resetAudit = () => {
 export const randomizeAnswer = writable(false);
 export const randomizeQuestion = writable(false);
 
-// Store original question order for mapping
-let originalQuestionOrder: QuestionType[] = [];
-let originalQuestionIndices: Map<QuestionType, number> = new Map();
+let originalItemOrder: AssessmentItem[] = [];
+let originalItemIndices: Map<AssessmentItem, number> = new Map();
 let originalAnswerOrders: Map<string, { id: string; originalIndex: number }[]> = new Map();
 
 const shuffleArray = <T>(array: T[]): T[] => {
@@ -129,160 +122,137 @@ const shuffleArray = <T>(array: T[]): T[] => {
   return shuffled;
 };
 
-const randomizeQuestions = () => {
-  const currentQuestions = get(questions);
-  if (currentQuestions.length === 0) return;
-  
-  const nonInstructions = currentQuestions.filter(q => 
-    q.type !== 'Instruction' && 
-    q.type !== 'Instruction QCM' && 
-    q.type !== 'Instruction QO'
-  );
-  
-  if (originalQuestionOrder.length === 0) {
-    originalQuestionOrder = [...currentQuestions];
-    currentQuestions.forEach((q, i) => originalQuestionIndices.set(q, i));
+const randomizeItems = () => {
+  const current = get(activeItems);
+  if (current.length === 0) return;
+
+  if (originalItemOrder.length === 0) {
+    originalItemOrder = [...current];
+    current.forEach((item, i) => originalItemIndices.set(item, i));
   }
-  
-  const instructionCount = currentQuestions.filter(q => 
-    q.type === 'Instruction' || 
-    q.type === 'Instruction QCM' || 
-    q.type === 'Instruction QO'
-  ).length;
-  
-  const shuffled = shuffleArray(nonInstructions);
-  const instructions = currentQuestions.filter(q => 
-    q.type === 'Instruction' || 
-    q.type === 'Instruction QCM' || 
-    q.type === 'Instruction QO'
-  );
-  
-  questions.set([...instructions, ...shuffled]);
+
+  const nonInstructions = current.filter(item => item.type !== 'instruction');
+  const instructions = current.filter(item => item.type === 'instruction');
+  activeItems.set([...instructions, ...shuffleArray(nonInstructions)]);
 };
 
-const unrandomizeQuestions = () => {
-  if (originalQuestionOrder.length > 0) {
-    questions.set([...originalQuestionOrder]);
+const unrandomizeItems = () => {
+  if (originalItemOrder.length > 0) {
+    activeItems.set([...originalItemOrder]);
   }
 };
 
 randomizeQuestion.subscribe((value) => {
-  if (value) {
-    randomizeQuestions();
-  } else {
-    unrandomizeQuestions();
-  }
+  if (value) randomizeItems();
+  else unrandomizeItems();
 });
 
-export const getQuestionMapping = (currentQuestions: QuestionType[]): { currentIndex: number; originalIndex: number; title: string; type: string }[] => {
-  return currentQuestions.map((q, currentIdx) => {
-    const originalIdx = originalQuestionIndices.get(q) ?? currentIdx;
-    return {
-      currentIndex: currentIdx + 1,
-      originalIndex: originalIdx + 1,
-      title: q.title,
-      type: q.type
-    };
+export const getQuestionMapping = (items: AssessmentItem[]): { currentIndex: number; originalIndex: number; title: string; type: string }[] => {
+  return items.map((item, currentIdx) => {
+    const originalIdx = originalItemIndices.get(item) ?? currentIdx;
+    return { currentIndex: currentIdx + 1, originalIndex: originalIdx + 1, title: item.title, type: item.type };
   });
 };
 
-export const questionMapping = derived([questions, randomizeQuestion, randomizeAnswer], ([$questions, $randomizeQuestion, $randomizeAnswer]) => {
-  if ((!$randomizeQuestion && !$randomizeAnswer) || $questions.length === 0) return [];
-  return getQuestionMapping($questions);
-});
-
-export const answerMapping = derived([questions, randomizeAnswer], ([$questions, $randomizeAnswer]) => {
-  if (!$randomizeAnswer || $questions.length === 0) return [];
-  return $questions
-    .filter(q => q.type === 'QCM')
-    .map(q => ({
-      title: q.title,
-      mapping: getAnswerMapping(q.title, q.answers)
-    }))
-    .filter(item => item.mapping.length > 0);
-});
-
-export const shuffleCurrentAnswers = (question: QuestionType): QuestionType => {
-  if (originalAnswerOrders.has(question.title)) {
-    const currentOrder = originalAnswerOrders.get(question.title)!;
-    const restored = currentOrder.map(order => 
-      question.answers.find(a => a.id === order.id) || question.answers[order.originalIndex]
-    ).filter(Boolean);
-    return { ...question, answers: restored as typeof question.answers };
+export const questionMapping = derived(
+  [activeItems, randomizeQuestion, randomizeAnswer],
+  ([$items, $rq, $ra]) => {
+    if ((!$rq && !$ra) || $items.length === 0) return [];
+    return getQuestionMapping($items);
   }
-  
-  const newOrder = question.answers.map((a, i) => ({ id: a.id, originalIndex: i }));
-  originalAnswerOrders.set(question.title, newOrder);
-  
-  const shuffled = shuffleArray(question.answers);
-  return { ...question, answers: shuffled };
+);
+
+export const answerMapping = derived(
+  [activeItems, randomizeAnswer],
+  ([$items, $ra]) => {
+    if (!$ra || $items.length === 0) return [];
+    return $items
+      .filter(item => item.type === 'single-choice')
+      .map(item => ({
+        title: item.title,
+        mapping: getAnswerMapping(item.title, item.responses?.[0]?.options ?? [])
+      }))
+      .filter(entry => entry.mapping.length > 0);
+  }
+);
+
+export const shuffleCurrentAnswers = (item: AssessmentItem): AssessmentItem => {
+  const resp = item.responses?.[0];
+  if (!resp?.options) return item;
+
+  if (originalAnswerOrders.has(item.title)) {
+    const order = originalAnswerOrders.get(item.title)!;
+    const restored = order
+      .map(o => resp.options!.find(a => a.id === o.id) ?? resp.options![o.originalIndex])
+      .filter(Boolean) as typeof resp.options;
+    return { ...item, responses: [{ ...resp, options: restored }, ...(item.responses?.slice(1) ?? [])] };
+  }
+
+  const newOrder = resp.options.map((a, i) => ({ id: a.id, originalIndex: i }));
+  originalAnswerOrders.set(item.title, newOrder);
+  const shuffled = shuffleArray(resp.options);
+  return { ...item, responses: [{ ...resp, options: shuffled }, ...(item.responses?.slice(1) ?? [])] };
 };
 
 randomizeAnswer.subscribe((value) => {
-  const currentQuestions = get(questions);
-  if (currentQuestions.length === 0) return;
-  
+  const current = get(activeItems);
+  if (current.length === 0) return;
+
   if (value) {
-    questions.update(qs => qs.map(q => {
-      if ((q.type === 'QCM' || q.type === 'Instruction QCM') && q.answers.length > 0) {
-        if (!originalAnswerOrders.has(q.title)) {
-          const newOrder = q.answers.map((a, i) => ({ id: a.id, originalIndex: i }));
-          originalAnswerOrders.set(q.title, newOrder);
-          const shuffled = shuffleArray(q.answers);
-          return { ...q, answers: shuffled };
+    activeItems.update(items =>
+      items.map(item => {
+        const resp = item.responses?.[0];
+        if (item.type !== 'single-choice' || !resp?.options?.length) return item;
+        if (!originalAnswerOrders.has(item.title)) {
+          const newOrder = resp.options.map((a, i) => ({ id: a.id, originalIndex: i }));
+          originalAnswerOrders.set(item.title, newOrder);
+          return { ...item, responses: [{ ...resp, options: shuffleArray(resp.options) }, ...(item.responses?.slice(1) ?? [])] };
         }
-        return q;
-      }
-      return q;
-    }));
+        return item;
+      })
+    );
   } else {
-    questions.update(qs => qs.map(q => {
-      if ((q.type === 'QCM' || q.type === 'Instruction QCM') && originalAnswerOrders.has(q.title)) {
-        const currentOrder = originalAnswerOrders.get(q.title)!;
-        const restored = currentOrder.map(order => 
-          q.answers.find(a => a.id === order.id) || q.answers[order.originalIndex]
-        ).filter(Boolean) as typeof q.answers;
-        originalAnswerOrders.delete(q.title);
-        return { ...q, answers: restored };
-      }
-      return q;
-    }));
+    activeItems.update(items =>
+      items.map(item => {
+        const resp = item.responses?.[0];
+        if (item.type !== 'single-choice' || !resp?.options) return item;
+        const order = originalAnswerOrders.get(item.title);
+        if (!order) return item;
+        const restored = order
+          .map(o => resp.options!.find(a => a.id === o.id) ?? resp.options![o.originalIndex])
+          .filter(Boolean) as typeof resp.options;
+        originalAnswerOrders.delete(item.title);
+        return { ...item, responses: [{ ...resp, options: restored }, ...(item.responses?.slice(1) ?? [])] };
+      })
+    );
   }
 });
 
-export const getAnswerMapping = (questionTitle: string, currentAnswers: { id: string }[]): { currentIndex: number; originalIndex: number; id: string }[] => {
-  const originalOrder = originalAnswerOrders.get(questionTitle);
-  if (!originalOrder) return [];
-  
-  return currentAnswers.map((answer, currentIdx) => {
-    const originalEntry = originalOrder.find(o => o.id === answer.id);
-    return {
-      currentIndex: currentIdx + 1,
-      originalIndex: (originalEntry?.originalIndex ?? currentIdx) + 1,
-      id: answer.id
-    };
+export const getAnswerMapping = (title: string, options: { id: string }[]): { currentIndex: number; originalIndex: number; id: string }[] => {
+  const original = originalAnswerOrders.get(title);
+  if (!original) return [];
+  return options.map((opt, currentIdx) => {
+    const entry = original.find(o => o.id === opt.id);
+    return { currentIndex: currentIdx + 1, originalIndex: (entry?.originalIndex ?? currentIdx) + 1, id: opt.id };
   });
 };
 
 sort.subscribe((value) => {
   if (value) {
     sortQuestions();
-    oldQuestions.update((qs) => [...qs].sort((a, b) => {
-      if (a.type.includes('Instruction') || a.type === 'Instruction QCM')
-        return 1;
-      const aNumber = a.title.match(/\d+/);
-      const bNumber = b.title.match(/\d+/);
-      if (aNumber && bNumber) {
-        return Number(aNumber[0]) - Number(bNumber[0]);
-      }
+    oldItems.update(items => [...items].sort((a, b) => {
+      if (a.type === 'instruction') return 1;
+      if (b.type === 'instruction') return -1;
+      const aNum = a.title.match(/\d+/);
+      const bNum = b.title.match(/\d+/);
+      if (aNum && bNum) return Number(aNum[0]) - Number(bNum[0]);
       return 0;
     }));
   } else {
-    questions.set(get(oldQuestions));
+    activeItems.set(get(oldItems));
   }
 });
 
-// Disable compareMode when not in multiple files mode
 multiple.subscribe((value) => {
   if (!value) {
     compareMode.set(false);
@@ -294,12 +264,11 @@ multiple.subscribe((value) => {
 
 compareMode.subscribe((value) => {
   const isMultiple = get(multiple);
-  const examsArray = get(exams);
-  
-  if (value && isMultiple && examsArray.length > 1) {
-    // Initialize exam indices if not set
+  const list = get(assessments);
+
+  if (value && isMultiple && list.length > 1) {
     if (get(compareExamIndex1) === -1) compareExamIndex1.set(0);
-    if (get(compareExamIndex2) === -1) compareExamIndex2.set(examsArray.length > 1 ? 1 : 0);
+    if (get(compareExamIndex2) === -1) compareExamIndex2.set(list.length > 1 ? 1 : 0);
     currentPage.set('compare');
   } else if (!value) {
     compareExamIndex1.set(-1);
@@ -308,52 +277,30 @@ compareMode.subscribe((value) => {
   }
 });
 
-showInstruction.subscribe((showInstruction) => {
-  questions.update((o) => o.map((q) => ({
-    ...q,
-    show:
-      q.type === 'Instruction' ||
-        q.type === 'Instruction QCM' ||
-        q.type === 'Instruction QO'
-        ? showInstruction
-        : q.show,
-  })))
-  oldQuestions.update((o) => o.map((q) => ({
-    ...q,
-    show:
-      q.type === 'Instruction' ||
-        q.type === 'Instruction QCM' ||
-        q.type === 'Instruction QO'
-        ? showInstruction
-        : q.show,
-  })))
+merge.subscribe((merge) => {
+  const list = get(assessments);
+  const index = get(examsIndex);
+  let items: AssessmentItem[] = [];
+  if (merge) items = list.flatMap(a => a.sections.flatMap(s => s.items));
+  else if (list[index]) items = list[index].sections.flatMap(s => s.items);
+  activeItems.set(items);
+  oldItems.set([]);
+  showItems.set(new Map());
+  originalItemOrder = [];
+  originalItemIndices = new Map();
+  originalAnswerOrders = new Map();
 });
 
-merge.subscribe((merge) => {
-  const ex = get(exams);
-  const index = get(examsIndex);
-  let q: QuestionType[] = []
-  if (merge) q = ex.flatMap((e) => e.questions)
-  else if (ex[index]) q = ex[index].questions
-  else q = []
-  questions.set(q)
-  originalQuestionOrder = [];
-  originalQuestionIndices = new Map();
-  originalAnswerOrders = new Map();
-})
-
-// Derived Settings
-export const settings = derived([showAnswer, showInstruction, showLetter, inzage, sort], ([$showAnswer, $showInstruction, $showLetter, $inzage, $sort]) => {
-  return {
+export const settings = derived(
+  [showAnswer, showInstruction, showLetter, inzage, sort],
+  ([$showAnswer, $showInstruction, $showLetter, $inzage, $sort]) => ({
     showAnswer: $showAnswer,
     showInstruction: $showInstruction,
     showLetter: $showLetter,
     inzage: $inzage,
     sort: $sort
-  }
-});
-
-
+  })
+);
 
 export const resetSettings = () => {
   showAnswer.set(true);
@@ -361,24 +308,12 @@ export const resetSettings = () => {
   showLetter.set(false);
   inzage.set(false);
   sort.set(false);
-}
+};
 
-
-
-// Audit stats derived from report
 export const auditStats = derived([auditReport], ([$report]) => {
   if (!$report) {
-    return {
-      total: 0,
-      matched: 0,
-      unmatched: 0,
-      bloquants: 0,
-      majeurs: 0,
-      mineurs: 0,
-      status: 'idle' as const,
-    };
+    return { total: 0, matched: 0, unmatched: 0, bloquants: 0, majeurs: 0, mineurs: 0, status: 'idle' as const };
   }
-
   return {
     total: $report.summary.total,
     matched: $report.summary.matched,

--- a/mono/src/lib/export/template/QCM.svelte
+++ b/mono/src/lib/export/template/QCM.svelte
@@ -1,14 +1,13 @@
 <script lang="ts">
   import { run } from 'svelte/legacy';
-
-  import type { QuestionType } from '../helper';
+  import type { AssessmentItem } from '$lib/questions/types.js';
   import { showLetter, showAnswer, inzage } from '../store';
 
   interface Props {
-    question: QuestionType;
+    item: AssessmentItem;
   }
 
-  let { question }: Props = $props();
+  let { item }: Props = $props();
 
   let inzageSelection = $state(-1);
 
@@ -19,23 +18,29 @@
   });
 
   const onClick = (n: number) => {
+    const options = item.responses?.[0]?.options ?? [];
     if (inzageSelection == n) {
       inzageSelection = -1;
-    }
-    else if ($inzage && !question.answers[n].correct) {
+    } else if ($inzage && !options[n]?.correct) {
       inzageSelection = n;
     }
   };
+
+  function getScore(optId: string): number | string {
+    const mapping = item.responses?.[0]?.mapping;
+    if (mapping && optId in mapping) return mapping[optId];
+    const scoring = item.scoring?.rules?.find(r => r.answerId === optId);
+    return scoring?.score ?? 0;
+  }
 </script>
 
 <ul class="answers" class:alpha={$showLetter}>
-  {#each question.answers as answer, n}
-    {@const { txt, point, correct } = answer}
+  {#each item.responses?.[0]?.options ?? [] as option, n}
     <!-- svelte-ignore a11y_click_events_have_key_events -->
     <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
     <li
-      class:correct={(correct && $showAnswer && !$inzage) ||
-        (inzage && inzageSelection === n)}
+      class:correct={(option.correct && $showAnswer && !$inzage) ||
+        ($inzage && inzageSelection === n)}
       class="answer"
       onclick={() => onClick(n)}
     >
@@ -43,10 +48,10 @@
         {$showLetter ? String.fromCharCode(65 + n) : n + 1}
       </div>
       <div class="answer-text">
-        {@html txt}
+        {@html option.content.html ?? option.content.text ?? ''}
       </div>
       {#if $showAnswer}
-        <div class="points">{point || 0}</div>
+        <div class="points">{getScore(option.id)}</div>
       {/if}
     </li>
   {/each}
@@ -127,7 +132,6 @@
     width: 24px;
     height: 24px;
     padding: 0 8px;
-    /* Black by default (fixed across themes), green when correct. */
     background: #111827;
     color: #ffffff;
     border-radius: var(--radius);

--- a/mono/src/lib/export/template/Question.svelte
+++ b/mono/src/lib/export/template/Question.svelte
@@ -1,21 +1,19 @@
 <script lang="ts">
-  import type { QuestionType } from '../helper';
+  import type { AssessmentItem } from '$lib/questions/types.js';
   import Qcm from './QCM.svelte';
+
   interface Props {
-    question: QuestionType;
+    item: AssessmentItem;
+    show?: boolean;
     onToggleShow?: (show: boolean) => void;
   }
 
-  let { question = $bindable(), onToggleShow }: Props = $props();
-
-  let questionDom = $state();
+  let { item, show = true, onToggleShow }: Props = $props();
 </script>
 
-{#if question.show}
+{#if show}
   <div
     class="question"
-    bind:this={questionDom}
-    class:hidePrint={!question.show}
     style="page-break-inside: avoid !important; break-inside: avoid;"
   >
     <div class="title">
@@ -23,33 +21,29 @@
         <input
           class="hide-print"
           type="checkbox"
-          checked={question.show}
+          checked={show}
           onchange={(e) => onToggleShow?.(e.currentTarget.checked)}
         />
       </label>
-      <span class="title-text">{question.title}</span>
+      <span class="title-text">{item.title}</span>
     </div>
     <div
       class="prompt"
-      class:grid-row={question.type.includes('Instruction')}
+      class:grid-row={item.type === 'instruction'}
     >
-      {#each question.prompt as prompt, i}
-        {@html prompt.innerHTML}
-        <p class="maxChar">
-          {question.type == 'QO' && (question.maxLenght && question.maxLenght[i])
-            ? question.maxLenght[i] + ' caractères maximum.' || ''
-            : ''}
-        </p>
-      {/each}
+      {@html item.content.html ?? ''}
+      {#if item.type === 'text' && item.responses?.[0]?.constraints?.maxLength}
+        <p class="maxChar">{item.responses[0].constraints.maxLength} caractères maximum.</p>
+      {/if}
     </div>
-    {#if question.type === 'QCM' || question.type === 'Instruction QCM'}
-      <Qcm bind:question />
+    {#if item.type === 'single-choice' || item.type === 'multiple-choice'}
+      <Qcm {item} />
     {/if}
   </div>
 {:else}
   <div class="question question-hidden">
     <div class="title">
-      <span class="title-text">Question masquée: {question.title || 'sans titre'}</span>
+      <span class="title-text">Question masquée: {item.title || 'sans titre'}</span>
     </div>
   </div>
 {/if}
@@ -69,8 +63,6 @@
     align-items: center;
     gap: 8px;
     padding: 5px 7px;
-    /* Black title bar, intentionally fixed across light/dark themes (no token
-       stays black in dark mode) and shared by the import + export previews. */
     background: #111827;
     color: #ffffff;
     font-size: 15px;
@@ -86,7 +78,6 @@
   .checkbox-wrapper input {
     width: 14px;
     height: 14px;
-    /* On the fixed black title bar regardless of theme. */
     accent-color: #ffffff;
     cursor: pointer;
   }
@@ -121,7 +112,7 @@
     margin-bottom: 0;
   }
 
-  .maxChar{
+  .maxChar {
     margin-top: 12px;
     font-size: 12px;
     color: var(--text-muted);
@@ -132,7 +123,7 @@
       break-inside: avoid;
     }
 
-    .question-hidden{
+    .question-hidden {
       display: none;
     }
 

--- a/mono/src/lib/export/template/Question.svelte
+++ b/mono/src/lib/export/template/Question.svelte
@@ -27,10 +27,7 @@
       </label>
       <span class="title-text">{item.title}</span>
     </div>
-    <div
-      class="prompt"
-      class:grid-row={item.type === 'instruction'}
-    >
+    <div class="prompt">
       {@html item.content.html ?? ''}
       {#if item.type === 'text' && item.responses?.[0]?.constraints?.maxLength}
         <p class="maxChar">{item.responses[0].constraints.maxLength} caractères maximum.</p>
@@ -91,7 +88,9 @@
     line-height: 1.5;
   }
 
-  .grid-row {
+  /* Each QTI grid-row is its own full-width row that stacks vertically;
+     its col-* children lay out as columns within that row. */
+  .prompt :global(.grid-row) {
     width: 100%;
     display: flex;
     flex-wrap: wrap;

--- a/mono/src/lib/import/helper/toQuestionType.ts
+++ b/mono/src/lib/import/helper/toQuestionType.ts
@@ -1,13 +1,6 @@
-import type { QuestionType } from "$lib/export/helper";
+import type { AssessmentItem } from "$lib/questions/types.js";
 import type { QCM } from "./question";
 
-/**
- * Spreadsheet cells can carry rich text, whose string form (`.r`) is raw
- * SpreadsheetML markup such as `<t>Question 01</t>`. That was harmless when the
- * legacy preview rendered it via `{@html}` (the browser dropped the unknown
- * `<t>` tag), but the shared export component renders the title as plain text,
- * so the tags would leak through. Strip any markup to get clean plain text.
- */
 function plainText(txt: { w?: string; r?: string; v?: string } | undefined): string {
   if (!txt) return "";
   const raw = txt.w ?? txt.r ?? txt.v ?? "";
@@ -16,40 +9,46 @@ function plainText(txt: { w?: string; r?: string; v?: string } | undefined): str
     .trim();
 }
 
-/**
- * Adapt the import-side `QCM` model into the export-side `QuestionType` so the
- * import preview can be rendered with the exact same `Question.svelte`
- * component the export route uses. Keeping a single renderer guarantees both
- * routes stay visually and behaviourally in sync.
- */
-export function qcmToQuestionType(qcm: QCM): QuestionType {
-  // The export renderer expects each prompt entry to be an Element it reads
-  // `innerHTML` from. Wrap the rich-text string in a detached element so the
-  // markup survives untouched.
-  const promptEl =
-    typeof document !== "undefined"
-      ? document.createElement("div")
-      : ({ innerHTML: "" } as unknown as HTMLDivElement);
-  promptEl.innerHTML = qcm.prompt?.toString() ?? "";
+export function qcmToAssessmentItem(qcm: QCM, index: number): AssessmentItem {
+  const options = qcm.answers.map((answer, i) => ({
+    id: `choice_${i + 1}`,
+    content: { html: answer.prompt?.toString() ?? "", text: answer.prompt?.toString() ?? "" },
+    correct: answer.correct,
+  }));
+
+  const correctId = options.find(o => o.correct)?.id;
+  const rules = options.map(o => ({
+    answerId: o.id,
+    score: o.correct ? options.length - 1 : -1
+  }));
 
   return {
+    id: `row_${index}`,
     title: plainText(qcm.id),
-    type: "QCM",
-    prompt: [promptEl],
-    answers: qcm.answers.map((answer, i) => ({
-      txt: answer.prompt?.toString() ?? "",
-      // No explicit scoring exists on the import side; mirror the historical
-      // PreviewTAO weighting (correct = 3, incorrect = -1).
-      point: answer.correct ? "3" : "-1",
-      id: String(i),
-      correct: answer.correct,
-    })),
-    maxLenght: [],
-    show: true,
+    type: 'single-choice',
+    content: { html: qcm.prompt?.toString() ?? "", text: qcm.prompt?.toString() ?? "" },
+    responses: [
+      {
+        id: 'RESPONSE',
+        cardinality: 'single',
+        baseType: 'identifier',
+        correctAnswers: correctId ? [correctId] : [],
+        options,
+        mapping: Object.fromEntries(rules.map(r => [r.answerId, r.score]))
+      }
+    ],
+    scoring: { maxScore: options.length - 1, rules },
+    metadata: {
+      competency: qcm.competency ? String(qcm.competency.v ?? '') : undefined,
+      indicator: qcm.indicator ? String(qcm.indicator.v ?? '') : undefined,
+    }
   };
 }
 
-
-export function qcmsToQuestionTypes(qcms: QCM[]): QuestionType[] {
-  return qcms.map(qcmToQuestionType);
+export function qcmsToAssessmentItems(qcms: QCM[]): AssessmentItem[] {
+  return qcms.map(qcmToAssessmentItem);
 }
+
+// Keep old names as aliases for backward compatibility during transition
+export const qcmToQuestionType = qcmToAssessmentItem;
+export const qcmsToQuestionTypes = qcmsToAssessmentItems;

--- a/mono/src/lib/questions/ExamToolsBadge.svelte
+++ b/mono/src/lib/questions/ExamToolsBadge.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+	import type { TaoTools, TimeLimits } from './types.js';
+	import { TOOL_LABELS } from './tao-tools.js';
+
+	interface Props {
+		tools: TaoTools;
+		timeLimits?: TimeLimits;
+	}
+
+	let { tools, timeLimits }: Props = $props();
+
+	const enabledTools = $derived(
+		Object.entries(tools)
+			.filter(([, v]) => v === true)
+			.map(([k]) => ({ key: k, label: TOOL_LABELS[k] ?? k }))
+	);
+
+	function formatTime(seconds: number): string {
+		const h = Math.floor(seconds / 3600);
+		const m = Math.floor((seconds % 3600) / 60);
+		if (h > 0) return `${h}h ${m.toString().padStart(2, '0')}min`;
+		return `${m}min`;
+	}
+</script>
+
+{#if enabledTools.length > 0 || timeLimits?.maxTime}
+	<div class="badge-row">
+		{#if timeLimits?.maxTime}
+			<span class="badge badge-time">
+				<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+					<circle cx="12" cy="12" r="10" /><polyline points="12 6 12 12 16 14" />
+				</svg>
+				{formatTime(timeLimits.maxTime)}
+			</span>
+		{/if}
+		{#each enabledTools as tool (tool.key)}
+			<span class="badge">{tool.label}</span>
+		{/each}
+	</div>
+{/if}
+
+<style>
+	.badge-row {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 6px;
+		align-items: center;
+	}
+
+	.badge {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		padding: 2px 8px;
+		border-radius: var(--radius);
+		border: 1px solid var(--border);
+		background: var(--surface-elevated);
+		color: var(--text-muted);
+		font-size: 11px;
+		font-weight: 500;
+		line-height: 1.6;
+		white-space: nowrap;
+	}
+
+	.badge-time {
+		color: var(--text);
+		border-color: var(--border-strong);
+	}
+</style>

--- a/mono/src/lib/questions/adapters/base.ts
+++ b/mono/src/lib/questions/adapters/base.ts
@@ -1,0 +1,30 @@
+import type { Assessment } from '../types.js';
+import type { ExcelConfig } from '$lib/export/audit/types.js';
+
+export interface AdapterReadOptions {
+	sheetName?: string;
+	assessmentId?: string;
+	assessmentTitle?: string;
+}
+
+export interface AdapterWriteOptions {
+	filename?: string;
+	lang?: string;
+	excelConfig?: ExcelConfig;
+}
+
+export interface AssessmentAdapter {
+	readonly name: string;
+	read(source: ArrayBuffer | File, options?: AdapterReadOptions): Promise<Assessment>;
+	write(assessment: Assessment, options?: AdapterWriteOptions): Promise<Blob>;
+}
+
+export class AdapterWriteNotSupportedError extends Error {
+	constructor(adapterName: string) {
+		super(
+			`The ${adapterName} adapter does not support writing. ` +
+				`Export to Excel, CSV, or JSON instead.`
+		);
+		this.name = 'AdapterWriteNotSupportedError';
+	}
+}

--- a/mono/src/lib/questions/adapters/csv.ts
+++ b/mono/src/lib/questions/adapters/csv.ts
@@ -1,0 +1,224 @@
+import { CSV } from '$lib/import/helper/csv.js';
+import type { Assessment, AssessmentItem, Section } from '../types.js';
+import type { AssessmentAdapter, AdapterReadOptions, AdapterWriteOptions } from './base.js';
+
+const HEADER = [
+	'name',
+	'question',
+	'shuffle',
+	'language',
+	'min_choices',
+	'max_choices',
+	'choice_1',
+	'choice_2',
+	'choice_3',
+	'choice_4',
+	'choice_5',
+	'choice_1_score',
+	'choice_2_score',
+	'choice_3_score',
+	'choice_4_score',
+	'choice_5_score',
+	'correct_answer',
+	'metadata_SpeccompetenceDecr',
+	'metadata_masteryDescr',
+	'metadata_Speccompetence',
+	'metadata_Specindicator'
+];
+
+const MAX_CHOICES = 5;
+
+export class CsvAdapter implements AssessmentAdapter {
+	readonly name = 'CSV';
+
+	async read(source: File | ArrayBuffer, options?: AdapterReadOptions): Promise<Assessment> {
+		const text =
+			source instanceof File
+				? await source.text()
+				: new TextDecoder().decode(source instanceof ArrayBuffer ? source : source);
+
+		const lines = text.split(/\r?\n/).filter((l) => l.trim());
+		if (lines.length < 2) {
+			return {
+				id: options?.assessmentId ?? 'csv-import',
+				title: options?.assessmentTitle ?? 'CSV Import',
+				metadata: { tools: {} },
+				sections: [{ id: 'main', title: 'Questions', items: [] }],
+				assets: {}
+			};
+		}
+
+		const headerLine = lines[0];
+		const cols = parseCsvLine(headerLine);
+		const colIndex = Object.fromEntries(cols.map((c, i) => [c, i]));
+
+		const items: AssessmentItem[] = [];
+
+		for (let r = 1; r < lines.length; r++) {
+			const row = parseCsvLine(lines[r]);
+			if (row.length === 0) continue;
+
+			const name = row[colIndex['name']] ?? '';
+			const question = row[colIndex['question']] ?? '';
+			const language = row[colIndex['language']] ?? '';
+			const correctAnswer = row[colIndex['correct_answer']] ?? '';
+			const competencyDescr = row[colIndex['metadata_SpeccompetenceDecr']] ?? '';
+			const masteryDescr = row[colIndex['metadata_masteryDescr']] ?? '';
+			const competency = row[colIndex['metadata_Speccompetence']] ?? '';
+			const indicator = row[colIndex['metadata_Specindicator']] ?? '';
+
+			const options = [];
+			for (let i = 1; i <= MAX_CHOICES; i++) {
+				const text = row[colIndex[`choice_${i}`]] ?? '';
+				if (!text) continue;
+				const choiceId = `choice_${i}`;
+				const score = Number(row[colIndex[`choice_${i}_score`]] ?? '-1');
+				options.push({
+					id: choiceId,
+					content: { html: text, text },
+					correct: correctAnswer === choiceId
+				});
+			}
+
+			const correctIndex = options.findIndex((o) => o.correct);
+			const correctId = correctIndex >= 0 ? options[correctIndex].id : undefined;
+			const rules = options.map((o, i) => ({
+				answerId: o.id,
+				score: o.correct ? options.length - 1 : -1
+			}));
+
+			const item: AssessmentItem = {
+				id: `row_${r}`,
+				title: name,
+				type: 'single-choice',
+				content: { html: question, text: question },
+				responses: [
+					{
+						id: 'RESPONSE',
+						cardinality: 'single',
+						baseType: 'identifier',
+						correctAnswers: correctId ? [correctId] : [],
+						options,
+						mapping: Object.fromEntries(rules.map((ru) => [ru.answerId, ru.score]))
+					}
+				],
+				scoring: {
+					maxScore: options.length - 1,
+					rules
+				},
+				metadata: {
+					competencyDescr: competencyDescr || undefined,
+					masteryDescr: masteryDescr || undefined,
+					competency: competency || undefined,
+					indicator: indicator || undefined
+				}
+			};
+
+			items.push(item);
+		}
+
+		const section: Section = {
+			id: 'main',
+			title: 'Questions',
+			items
+		};
+
+		return {
+			id: options?.assessmentId ?? 'csv-import',
+			title: options?.assessmentTitle ?? 'CSV Import',
+			metadata: { tools: {} },
+			sections: [section],
+			assets: {}
+		};
+	}
+
+	async write(assessment: Assessment, options?: AdapterWriteOptions): Promise<Blob> {
+		const lang = options?.lang ?? 'FR';
+		const { zone, titlePrefix } = langZone(lang);
+
+		const items = assessment.sections
+			.flatMap((s) => s.items)
+			.filter((i) => i.type !== 'instruction');
+
+		const csv = new CSV({ header: HEADER });
+
+		items.forEach((item, n) => {
+			const name = item.title || titlePrefix + (n + 1 < 10 ? '0' + (n + 1) : n + 1).toString();
+			const questionText = item.content.text ?? stripHtml(item.content.html ?? '');
+			const choiceOptions = item.responses?.[0]?.options ?? [];
+
+			csv.addSequentially(name);
+			csv.addSequentially(questionText);
+			csv.addSequentially(1);
+			csv.addSequentially(zone);
+			csv.addSequentially(0);
+			csv.addSequentially(1);
+
+			const offset = MAX_CHOICES - choiceOptions.length;
+			choiceOptions.forEach((opt) => {
+				csv.addSequentially(opt.content.text ?? stripHtml(opt.content.html ?? ''));
+			});
+			for (let i = 0; i < offset; i++) csv.addSequentially('');
+
+			choiceOptions.forEach((opt) => {
+				const score = item.responses?.[0]?.mapping?.[opt.id];
+				csv.addSequentially(score !== undefined ? score : opt.correct ? choiceOptions.length - 1 : -1);
+			});
+			for (let i = 0; i < offset; i++) csv.addSequentially('');
+
+			const correctIndex = choiceOptions.findIndex((o) => o.correct);
+			csv.addSequentially(correctIndex >= 0 ? `choice_${correctIndex + 1}` : '');
+
+			csv.addSequentially(item.metadata?.competencyDescr ?? '');
+			csv.addSequentially(item.metadata?.masteryDescr ?? '');
+			csv.addSequentially(item.metadata?.competency ?? '');
+			csv.addSequentially(item.metadata?.indicator ?? '');
+		});
+
+		const encoded = csv.toStringEncoded();
+		return new Blob([encoded], { type: 'text/csv;charset=utf-8;' });
+	}
+}
+
+function langZone(lang: string): { zone: string; titlePrefix: string } {
+	switch (lang.toUpperCase()) {
+		case 'FR':
+			return { zone: 'fr-FR', titlePrefix: 'QCM ' };
+		case 'NL':
+			return { zone: 'nl-NL', titlePrefix: 'MKV ' };
+		case 'DE':
+			return { zone: 'de-DE', titlePrefix: 'Frage ' };
+		default:
+			return { zone: lang, titlePrefix: 'Q ' };
+	}
+}
+
+function parseCsvLine(line: string): string[] {
+	const result: string[] = [];
+	let current = '';
+	let inQuotes = false;
+	let i = 0;
+	while (i < line.length) {
+		const ch = line[i];
+		if (ch === '"') {
+			if (inQuotes && line[i + 1] === '"') {
+				current += '"';
+				i += 2;
+				continue;
+			}
+			inQuotes = !inQuotes;
+		} else if (ch === ';' && !inQuotes) {
+			result.push(current);
+			current = '';
+		} else {
+			current += ch;
+		}
+		i++;
+	}
+	result.push(current);
+	return result;
+}
+
+function stripHtml(html: string): string {
+	return html.replace(/<[^>]*>/g, '').replace(/&nbsp;/g, ' ').trim();
+}

--- a/mono/src/lib/questions/adapters/excel.ts
+++ b/mono/src/lib/questions/adapters/excel.ts
@@ -1,0 +1,166 @@
+import * as XLSX from 'xlsx';
+import { parseExcel } from '$lib/export/audit/excel-parser.js';
+import type { ExcelConfig, ExcelQuestion } from '$lib/export/audit/types.js';
+import type { Assessment, AssessmentItem, Section } from '../types.js';
+import type { AssessmentAdapter, AdapterReadOptions, AdapterWriteOptions } from './base.js';
+import { DEFAULT_CONFIG } from '$lib/export/audit/config.js';
+
+const DEFAULT_WRITE_CONFIG: ExcelConfig = DEFAULT_CONFIG;
+
+export class ExcelAdapter implements AssessmentAdapter {
+	readonly name = 'Excel';
+
+	async read(source: File | ArrayBuffer, options?: AdapterReadOptions): Promise<Assessment> {
+		const buffer =
+			source instanceof File ? await source.arrayBuffer() : (source as ArrayBuffer);
+
+		const config: ExcelConfig = DEFAULT_WRITE_CONFIG;
+		const excelQuestions = await parseExcel(buffer, config, options?.sheetName);
+
+		const items = excelQuestions.map(excelQuestionToItem);
+
+		const section: Section = {
+			id: 'main',
+			title: 'Questions',
+			items
+		};
+
+		return {
+			id: options?.assessmentId ?? 'excel-import',
+			title: options?.assessmentTitle ?? 'Excel Import',
+			metadata: { tools: {} },
+			sections: [section],
+			assets: {}
+		};
+	}
+
+	async write(assessment: Assessment, options?: AdapterWriteOptions): Promise<Blob> {
+		const config: ExcelConfig = options?.excelConfig ?? DEFAULT_WRITE_CONFIG;
+		const items = assessment.sections.flatMap((s) => s.items).filter((i) => i.type !== 'instruction');
+
+		const wb = XLSX.utils.book_new();
+		const rows: (string | number | undefined)[][] = [];
+
+		// Header row
+		const headerRow: string[] = [];
+		if (config.columns.title) headerRow[colIndex(config.columns.title)] = 'Titre';
+		headerRow[colIndex(config.columns.prompt)] = 'Question';
+		if (config.answerLayout === 'spread_columns' && Array.isArray(config.columns.answers)) {
+			for (let i = 0; i < config.columns.answers.length; i++) {
+				headerRow[colIndex(config.columns.answers[i])] = `Réponse ${i + 1}`;
+			}
+		} else if (config.answerLayout === 'same_column' && typeof config.columns.answers === 'string') {
+			headerRow[colIndex(config.columns.answers)] = 'Réponse';
+			if (config.columns.answerMarker) headerRow[colIndex(config.columns.answerMarker)] = 'Correct';
+		}
+		if (config.columns.competency) headerRow[colIndex(config.columns.competency)] = 'Compétence';
+		if (config.columns.indicator) headerRow[colIndex(config.columns.indicator)] = 'Indicateur';
+
+		// Pad rows to rowOffset
+		for (let i = 0; i < config.rowOffset; i++) {
+			rows.push(i === 0 ? headerRow : []);
+		}
+
+		for (const item of items) {
+			const options = item.responses?.[0]?.options ?? [];
+			const promptText = stripHtml(item.content.html ?? '');
+			const titleText = item.title;
+
+			if (config.answerLayout === 'spread_columns') {
+				const row: (string | undefined)[] = [];
+				if (config.columns.title) row[colIndex(config.columns.title)] = titleText;
+				row[colIndex(config.columns.prompt)] = promptText;
+				if (Array.isArray(config.columns.answers)) {
+					for (let i = 0; i < config.columns.answers.length; i++) {
+						row[colIndex(config.columns.answers[i])] = stripHtml(options[i]?.content?.html ?? '');
+					}
+				}
+				if (config.columns.competency)
+					row[colIndex(config.columns.competency)] = item.metadata?.competency ?? '';
+				if (config.columns.indicator)
+					row[colIndex(config.columns.indicator)] = item.metadata?.indicator ?? '';
+				rows.push(row);
+				for (let s = 0; s < config.skipRows; s++) rows.push([]);
+			} else {
+				// same_column: prompt row + answer rows
+				const promptRow: (string | undefined)[] = [];
+				if (config.columns.title) promptRow[colIndex(config.columns.title)] = titleText;
+				promptRow[colIndex(config.columns.prompt)] = promptText;
+				if (config.columns.competency)
+					promptRow[colIndex(config.columns.competency)] = item.metadata?.competency ?? '';
+				if (config.columns.indicator)
+					promptRow[colIndex(config.columns.indicator)] = item.metadata?.indicator ?? '';
+				rows.push(promptRow);
+
+				for (const opt of options) {
+					const ansRow: (string | undefined)[] = [];
+					if (typeof config.columns.answers === 'string') {
+						ansRow[colIndex(config.columns.answers)] = stripHtml(opt.content?.html ?? '');
+					}
+					if (config.columns.answerMarker) {
+						ansRow[colIndex(config.columns.answerMarker)] = opt.correct ? 'X' : '';
+					}
+					rows.push(ansRow);
+				}
+				for (let s = 0; s < config.skipRows; s++) rows.push([]);
+			}
+		}
+
+		const ws = XLSX.utils.aoa_to_sheet(rows);
+		XLSX.utils.book_append_sheet(wb, ws, 'Questions');
+		const buf = XLSX.write(wb, { bookType: 'xlsx', type: 'array' });
+		return new Blob([buf], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+	}
+}
+
+function excelQuestionToItem(eq: ExcelQuestion): AssessmentItem {
+	const options = eq.answers.map((text, i) => ({
+		id: `choice_${i + 1}`,
+		content: { html: text, text },
+		correct: i === eq.correctAnswerIndex
+	}));
+
+	const correctId = `choice_${eq.correctAnswerIndex + 1}`;
+	const rules = eq.answers.map((_, i) => ({
+		answerId: `choice_${i + 1}`,
+		score: i === eq.correctAnswerIndex ? 3 : -1
+	}));
+
+	return {
+		id: `row_${eq.rowIndex}`,
+		title: eq.title ?? '',
+		type: 'single-choice',
+		content: { html: eq.prompt, text: eq.prompt },
+		responses: [
+			{
+				id: 'RESPONSE',
+				cardinality: 'single',
+				baseType: 'identifier',
+				correctAnswers: [correctId],
+				options,
+				mapping: Object.fromEntries(rules.map((r) => [r.answerId, r.score]))
+			}
+		],
+		scoring: {
+			maxScore: 3,
+			rules
+		},
+		metadata: {
+			sourceRow: eq.rowIndex,
+			competency: eq.competency,
+			indicator: eq.indicator
+		}
+	};
+}
+
+function colIndex(col: string): number {
+	let n = 0;
+	for (const ch of col.toUpperCase()) {
+		n = n * 26 + (ch.charCodeAt(0) - 64);
+	}
+	return n - 1;
+}
+
+function stripHtml(html: string): string {
+	return html.replace(/<[^>]*>/g, '').replace(/&nbsp;/g, ' ').trim();
+}

--- a/mono/src/lib/questions/adapters/json.ts
+++ b/mono/src/lib/questions/adapters/json.ts
@@ -1,0 +1,31 @@
+import type { Assessment } from '../types.js';
+import type { AssessmentAdapter, AdapterReadOptions, AdapterWriteOptions } from './base.js';
+
+export class JsonAdapter implements AssessmentAdapter {
+	readonly name = 'JSON';
+
+	async read(source: File | ArrayBuffer, options?: AdapterReadOptions): Promise<Assessment> {
+		const text =
+			source instanceof File
+				? await source.text()
+				: new TextDecoder().decode(source instanceof ArrayBuffer ? source : source);
+
+		const data = JSON.parse(text) as Assessment;
+
+		if (options?.assessmentId) data.id = options.assessmentId;
+		if (options?.assessmentTitle) data.title = options.assessmentTitle;
+
+		return data;
+	}
+
+	async write(assessment: Assessment, _options?: AdapterWriteOptions): Promise<Blob> {
+		const serializable = {
+			...assessment,
+			assets: Object.fromEntries(
+				Object.entries(assessment.assets).map(([k, v]) => [k, { ...v, blob: undefined }])
+			)
+		};
+		const json = JSON.stringify(serializable, null, 2);
+		return new Blob([json], { type: 'application/json' });
+	}
+}

--- a/mono/src/lib/questions/adapters/qti.ts
+++ b/mono/src/lib/questions/adapters/qti.ts
@@ -35,8 +35,10 @@ export class QtiAdapter implements AssessmentAdapter {
 				!e.filename.toLowerCase().endsWith('.css')
 		);
 
-		// Find test.xml
-		const testEntry = xmlEntries.find((e) => e.filename.includes('/tests/'));
+		// Find test.xml (entry paths may or may not have a leading slash)
+		const testEntry =
+			xmlEntries.find((e) => /(^|\/)tests\//.test(e.filename)) ??
+			xmlEntries.find((e) => e.filename.toLowerCase().endsWith('test.xml'));
 		if (!testEntry) throw new Error('No test.xml found in ZIP');
 
 		const testXmlText = await testEntry.getData(new TextWriter());
@@ -63,11 +65,14 @@ export class QtiAdapter implements AssessmentAdapter {
 
 		let overallMaxTime = 0;
 
-		// item ref map: itemId → { href, tools, informational, sectionId, testPart }
+		// Refs are linked to item files by href (the ref @identifier differs from the
+		// item file's own @identifier), so we key everything by a normalized href.
 		const itemRefMap = new Map<
 			string,
-			{ href: string; tools: TaoTools; informational: boolean; sectionId: string; testPart: string }
+			{ refId: string; tools: TaoTools; informational: boolean; sectionId: string; testPart: string }
 		>();
+		// Preserves test.xml order for placing items into sections.
+		const refOrder: { key: string; sectionId: string }[] = [];
 		const sections: Section[] = [];
 
 		for (const tp of testPartEls) {
@@ -83,10 +88,14 @@ export class QtiAdapter implements AssessmentAdapter {
 				const secMaxTime = secTl ? Number(secTl.getAttribute('maxTime') ?? 0) : undefined;
 
 				for (const ref of Array.from(sectionEl.querySelectorAll('assessmentItemRef'))) {
-					const itemId = ref.getAttribute('identifier') ?? '';
+					const refId = ref.getAttribute('identifier') ?? '';
 					const href = ref.getAttribute('href') ?? '';
+					const key = itemKey(href);
 					const { tools, informational } = parseCategory(ref.getAttribute('category'));
-					if (itemId) itemRefMap.set(itemId, { href, tools, informational, sectionId, testPart: testPartId });
+					if (key) {
+						itemRefMap.set(key, { refId, tools, informational, sectionId, testPart: testPartId });
+						refOrder.push({ key, sectionId });
+					}
 				}
 
 				sections.push({
@@ -109,9 +118,11 @@ export class QtiAdapter implements AssessmentAdapter {
 		const assets: Record<string, Asset> = {};
 		const itemAssets: Record<string, string[]> = {};
 
-		// Parse item XMLs
-		const itemXmlEntries = xmlEntries.filter((e) => e.filename.includes('/items/'));
-		const itemById = new Map<string, AssessmentItem>();
+		// Parse item XMLs (entry paths may or may not have a leading slash)
+		const itemXmlEntries = xmlEntries.filter(
+			(e) => /(^|\/)items\//.test(e.filename) || e.filename.toLowerCase().endsWith('qti.xml')
+		);
+		const itemByKey = new Map<string, AssessmentItem>();
 
 		let examLanguage: string | undefined;
 
@@ -122,6 +133,7 @@ export class QtiAdapter implements AssessmentAdapter {
 			const assessmentItemEl = doc.querySelector('assessmentItem');
 			if (!assessmentItemEl) continue;
 
+			const key = itemKey(xmlEntry.filename);
 			const itemId = assessmentItemEl.getAttribute('identifier') ?? xmlEntry.filename;
 			const itemTitle = assessmentItemEl.getAttribute('title') ?? 'unknown';
 			const itemLabel = assessmentItemEl.getAttribute('label') ?? undefined;
@@ -156,7 +168,7 @@ export class QtiAdapter implements AssessmentAdapter {
 			if (itemAssetIds.length) itemAssets[itemId] = itemAssetIds;
 
 			const item = parseItem(doc, itemId, itemTitle, itemLabel, itemAssets);
-			const ref = itemRefMap.get(itemId);
+			const ref = itemRefMap.get(key);
 			if (ref) {
 				item.metadata = {
 					...item.metadata,
@@ -164,19 +176,18 @@ export class QtiAdapter implements AssessmentAdapter {
 					informational: ref.informational || undefined
 				};
 			}
-			itemById.set(itemId, item);
+			itemByKey.set(key, item);
 		}
 
 		// Place items into sections in test.xml order
 		let allTools: TaoTools = {};
-		for (const section of sections) {
-			for (const [itemId, ref] of itemRefMap.entries()) {
-				if (ref.sectionId !== section.id) continue;
-				const item = itemById.get(itemId);
-				if (item) {
-					section.items.push(item);
-					if (item.metadata?.tools) allTools = mergeTools(allTools, item.metadata.tools);
-				}
+		const sectionById = new Map(sections.map((s) => [s.id, s]));
+		for (const { key, sectionId } of refOrder) {
+			const section = sectionById.get(sectionId);
+			const item = itemByKey.get(key);
+			if (section && item) {
+				section.items.push(item);
+				if (item.metadata?.tools) allTools = mergeTools(allTools, item.metadata.tools);
 			}
 		}
 
@@ -198,6 +209,16 @@ export class QtiAdapter implements AssessmentAdapter {
 	async write(_assessment: Assessment, _options?: AdapterWriteOptions): Promise<Blob> {
 		throw new AdapterWriteNotSupportedError(this.name);
 	}
+}
+
+/**
+ * Normalize a test.xml href ("../../items/iXXXX/qti.xml") or a ZIP entry path
+ * ("items/iXXXX/qti.xml") to a stable key ("iXXXX/qti.xml") so refs and item
+ * files can be joined regardless of relative-path prefixes.
+ */
+function itemKey(path: string): string {
+	const parts = path.split('/').filter((p) => p && p !== '..' && p !== '.');
+	return parts.slice(-2).join('/');
 }
 
 function parseItem(

--- a/mono/src/lib/questions/adapters/qti.ts
+++ b/mono/src/lib/questions/adapters/qti.ts
@@ -1,0 +1,331 @@
+import { ZipReader, TextWriter, BlobWriter, type FileEntry } from '@zip.js/zip.js';
+import type {
+	Assessment,
+	AssessmentItem,
+	AssessmentMetadata,
+	Section,
+	ChoiceOption,
+	ResponseDefinition,
+	ResponseConstraints,
+	Scoring,
+	Asset,
+	TaoTools,
+	ItemType
+} from '../types.js';
+import { parseCategory, mergeTools } from '../tao-tools.js';
+import type { AssessmentAdapter, AdapterReadOptions, AdapterWriteOptions } from './base.js';
+import { AdapterWriteNotSupportedError } from './base.js';
+
+export class QtiAdapter implements AssessmentAdapter {
+	readonly name = 'QTI 2.2';
+
+	async read(source: File, options?: AdapterReadOptions): Promise<Assessment> {
+		const zipReader = new ZipReader(source.stream());
+		const entries = await zipReader.getEntries();
+
+		const fileEntries = entries.filter((e): e is FileEntry => !e.directory);
+		const xmlEntries = fileEntries.filter(
+			(e) =>
+				e.filename.toLowerCase().endsWith('.xml') &&
+				!e.filename.toLowerCase().endsWith('imsmanifest.xml')
+		);
+		const assetEntries = fileEntries.filter(
+			(e) =>
+				!e.filename.toLowerCase().endsWith('.xml') &&
+				!e.filename.toLowerCase().endsWith('.css')
+		);
+
+		// Find test.xml
+		const testEntry = xmlEntries.find((e) => e.filename.includes('/tests/'));
+		if (!testEntry) throw new Error('No test.xml found in ZIP');
+
+		const testXmlText = await testEntry.getData(new TextWriter());
+		const testDoc = new DOMParser().parseFromString(testXmlText, 'text/xml');
+
+		const assessmentTest = testDoc.querySelector('assessmentTest');
+		if (!assessmentTest) throw new Error('No assessmentTest element found');
+
+		const id = assessmentTest.getAttribute('identifier') ?? options?.assessmentId ?? 'unknown';
+		const title = assessmentTest.getAttribute('title') ?? options?.assessmentTitle ?? 'Untitled';
+		const toolName = assessmentTest.getAttribute('toolName') ?? undefined;
+		const toolVersion = assessmentTest.getAttribute('toolVersion') ?? undefined;
+
+		// Parse testParts for navigation mode and timeLimits
+		const testPartEls = Array.from(testDoc.querySelectorAll('testPart'));
+		const navigationMode = (testPartEls[0]?.getAttribute('navigationMode') ?? undefined) as
+			| 'linear'
+			| 'nonlinear'
+			| undefined;
+		const submissionMode = (testPartEls[0]?.getAttribute('submissionMode') ?? undefined) as
+			| 'individual'
+			| 'simultaneous'
+			| undefined;
+
+		let overallMaxTime = 0;
+
+		// item ref map: itemId → { href, tools, informational, sectionId, testPart }
+		const itemRefMap = new Map<
+			string,
+			{ href: string; tools: TaoTools; informational: boolean; sectionId: string; testPart: string }
+		>();
+		const sections: Section[] = [];
+
+		for (const tp of testPartEls) {
+			const testPartId = tp.getAttribute('identifier') ?? '';
+			const tpTl = tp.querySelector(':scope > timeLimits');
+			const tpMaxTime = tpTl ? Number(tpTl.getAttribute('maxTime') ?? 0) : 0;
+			if (tpMaxTime > overallMaxTime) overallMaxTime = tpMaxTime;
+
+			for (const sectionEl of Array.from(tp.querySelectorAll('assessmentSection'))) {
+				const sectionId = sectionEl.getAttribute('identifier') ?? '';
+				const sectionTitle = sectionEl.getAttribute('title') ?? '';
+				const secTl = sectionEl.querySelector(':scope > timeLimits');
+				const secMaxTime = secTl ? Number(secTl.getAttribute('maxTime') ?? 0) : undefined;
+
+				for (const ref of Array.from(sectionEl.querySelectorAll('assessmentItemRef'))) {
+					const itemId = ref.getAttribute('identifier') ?? '';
+					const href = ref.getAttribute('href') ?? '';
+					const { tools, informational } = parseCategory(ref.getAttribute('category'));
+					if (itemId) itemRefMap.set(itemId, { href, tools, informational, sectionId, testPart: testPartId });
+				}
+
+				sections.push({
+					id: sectionId,
+					title: sectionTitle,
+					testPart: testPartId,
+					timeLimits: tpMaxTime ? { maxTime: secMaxTime ?? tpMaxTime } : undefined,
+					items: []
+				});
+			}
+		}
+
+		// Build asset lookup by filename
+		const assetByFilename = new Map<string, (typeof assetEntries)[0]>();
+		for (const ae of assetEntries) {
+			const name = ae.filename.split('/').pop() ?? ae.filename;
+			assetByFilename.set(name, ae);
+		}
+
+		const assets: Record<string, Asset> = {};
+		const itemAssets: Record<string, string[]> = {};
+
+		// Parse item XMLs
+		const itemXmlEntries = xmlEntries.filter((e) => e.filename.includes('/items/'));
+		const itemById = new Map<string, AssessmentItem>();
+
+		let examLanguage: string | undefined;
+
+		for (const xmlEntry of itemXmlEntries) {
+			const xmlText = await xmlEntry.getData(new TextWriter());
+			const doc = new DOMParser().parseFromString(xmlText, 'text/xml');
+
+			const assessmentItemEl = doc.querySelector('assessmentItem');
+			if (!assessmentItemEl) continue;
+
+			const itemId = assessmentItemEl.getAttribute('identifier') ?? xmlEntry.filename;
+			const itemTitle = assessmentItemEl.getAttribute('title') ?? 'unknown';
+			const itemLabel = assessmentItemEl.getAttribute('label') ?? undefined;
+			const lang = assessmentItemEl.getAttribute('xml:lang') ?? undefined;
+			if (!examLanguage && lang) examLanguage = lang;
+
+			// Inject blob URLs for images
+			const imgs = Array.from(doc.getElementsByTagName('img'));
+			const itemAssetIds: string[] = [];
+			for (const img of imgs) {
+				const src = img.getAttribute('src');
+				if (!src) continue;
+				const filename = src.split('/').pop() ?? src;
+				const ae = assetByFilename.get(filename);
+				if (ae) {
+					const blobWriter = new BlobWriter();
+					const blob = await ae.getData(blobWriter);
+					const blobUrl = URL.createObjectURL(blob);
+					img.setAttribute('src', blobUrl);
+					if (!assets[filename]) {
+						assets[filename] = {
+							id: filename,
+							type: 'image',
+							path: src,
+							blob,
+							originalName: filename
+						};
+					}
+					itemAssetIds.push(filename);
+				}
+			}
+			if (itemAssetIds.length) itemAssets[itemId] = itemAssetIds;
+
+			const item = parseItem(doc, itemId, itemTitle, itemLabel, itemAssets);
+			const ref = itemRefMap.get(itemId);
+			if (ref) {
+				item.metadata = {
+					...item.metadata,
+					tools: Object.keys(ref.tools).length ? ref.tools : undefined,
+					informational: ref.informational || undefined
+				};
+			}
+			itemById.set(itemId, item);
+		}
+
+		// Place items into sections in test.xml order
+		let allTools: TaoTools = {};
+		for (const section of sections) {
+			for (const [itemId, ref] of itemRefMap.entries()) {
+				if (ref.sectionId !== section.id) continue;
+				const item = itemById.get(itemId);
+				if (item) {
+					section.items.push(item);
+					if (item.metadata?.tools) allTools = mergeTools(allTools, item.metadata.tools);
+				}
+			}
+		}
+
+		const metadata: AssessmentMetadata = {
+			source: source.name,
+			toolName,
+			toolVersion,
+			navigationMode,
+			submissionMode,
+			timeLimits: overallMaxTime > 0 ? { maxTime: overallMaxTime } : undefined,
+			tools: allTools
+		};
+
+		await zipReader.close();
+
+		return { id, title, language: examLanguage, metadata, sections, assets };
+	}
+
+	async write(_assessment: Assessment, _options?: AdapterWriteOptions): Promise<Blob> {
+		throw new AdapterWriteNotSupportedError(this.name);
+	}
+}
+
+function parseItem(
+	doc: Document,
+	id: string,
+	title: string,
+	label: string | undefined,
+	itemAssets: Record<string, string[]>
+): AssessmentItem {
+	const hasChoice = doc.querySelector('choiceInteraction') !== null;
+	const hasExtended = doc.querySelector('extendedTextInteraction, textEntryInteraction') !== null;
+	const hasMapping = doc.querySelector('mapping') !== null;
+
+	let type: ItemType;
+	if (hasChoice || hasMapping) {
+		const maxChoices = Number(doc.querySelector('choiceInteraction')?.getAttribute('maxChoices') ?? 1);
+		type = maxChoices > 1 ? 'multiple-choice' : 'single-choice';
+	} else if (hasExtended) {
+		type = 'text';
+	} else {
+		type = 'instruction';
+	}
+
+	// Build content HTML from itemBody
+	const itemBody = doc.querySelector('itemBody');
+	let contentHtml = '';
+	if (itemBody) {
+		const gridRows = Array.from(itemBody.getElementsByClassName('grid-row'));
+		if (gridRows.length > 0) {
+			const promptRows = hasChoice
+				? gridRows.filter((el) => el.getElementsByTagName('simpleChoice').length === 0)
+				: gridRows;
+			contentHtml = promptRows.map((el) => el.outerHTML).join('');
+			// Include <prompt> element content for choice/text interactions
+			if (hasChoice || hasExtended) {
+				const promptEls = Array.from(
+					doc.querySelectorAll(
+						'choiceInteraction > prompt, extendedTextInteraction > prompt, textEntryInteraction > prompt'
+					)
+				);
+				const extra = promptEls.map((el) => el.innerHTML).join('');
+				if (extra && !contentHtml.includes(extra)) contentHtml += extra;
+			}
+		} else {
+			contentHtml = itemBody.innerHTML;
+		}
+	}
+
+	// Parse response declarations
+	const responses: ResponseDefinition[] = [];
+	const scoring: Scoring = {};
+
+	for (const respDecl of Array.from(doc.querySelectorAll('responseDeclaration'))) {
+		const respId = respDecl.getAttribute('identifier') ?? 'RESPONSE';
+		const cardinality = (respDecl.getAttribute('cardinality') ?? 'single') as
+			| 'single'
+			| 'multiple'
+			| 'ordered';
+		const baseType = (respDecl.getAttribute('baseType') ?? 'identifier') as
+			| 'identifier'
+			| 'string'
+			| 'integer'
+			| 'float';
+
+		const correctAnswers = Array.from(respDecl.querySelectorAll('correctResponse > value'))
+			.map((el) => el.textContent?.trim() ?? '')
+			.filter(Boolean);
+
+		const mappingEl = respDecl.querySelector('mapping');
+		const mapping: Record<string, number> = {};
+		if (mappingEl) {
+			for (const entry of Array.from(mappingEl.querySelectorAll('mapEntry'))) {
+				const key = entry.getAttribute('mapKey') ?? '';
+				const val = Number(entry.getAttribute('mappedValue') ?? 0);
+				if (key) mapping[key] = val;
+			}
+		}
+
+		// Parse choice options
+		const options: ChoiceOption[] = [];
+		if (hasChoice) {
+			for (const choice of Array.from(doc.querySelectorAll('simpleChoice'))) {
+				const choiceId = choice.getAttribute('identifier') ?? '';
+				options.push({
+					id: choiceId,
+					content: { html: choice.innerHTML },
+					correct: correctAnswers.includes(choiceId)
+				});
+			}
+		}
+
+		// Build scoring rules
+		const rules = Object.entries(mapping).map(([answerId, score]) => ({ answerId, score }));
+		if (rules.length > 0) {
+			scoring.maxScore = Math.max(...rules.map((r) => r.score));
+			scoring.rules = rules;
+		}
+
+		// QO constraints from patternMask
+		let constraints: ResponseConstraints | undefined;
+		const extText = doc.querySelector('extendedTextInteraction');
+		if (extText) {
+			const patternMask = extText.getAttribute('patternMask');
+			if (patternMask) {
+				const m = patternMask.match(/\{0,(\d+)\}/);
+				if (m) constraints = { maxLength: Number(m[1]) };
+			}
+		}
+
+		responses.push({
+			id: respId,
+			cardinality,
+			baseType,
+			correctAnswers: correctAnswers.length ? correctAnswers : undefined,
+			options: options.length ? options : undefined,
+			mapping: Object.keys(mapping).length ? mapping : undefined,
+			constraints
+		});
+	}
+
+	return {
+		id,
+		title,
+		label,
+		type,
+		content: { html: contentHtml },
+		responses: responses.length ? responses : undefined,
+		scoring: scoring.rules?.length ? scoring : undefined,
+		assets: itemAssets[id]
+	};
+}

--- a/mono/src/lib/questions/index.ts
+++ b/mono/src/lib/questions/index.ts
@@ -1,0 +1,7 @@
+export * from './types.js';
+export * from './tao-tools.js';
+export * from './adapters/base.js';
+export { QtiAdapter } from './adapters/qti.js';
+export { ExcelAdapter } from './adapters/excel.js';
+export { CsvAdapter } from './adapters/csv.js';
+export { JsonAdapter } from './adapters/json.js';

--- a/mono/src/lib/questions/tao-tools.ts
+++ b/mono/src/lib/questions/tao-tools.ts
@@ -1,0 +1,45 @@
+import type { TaoTools } from './types.js';
+
+const CATEGORY_TO_TOOL: Record<string, keyof TaoTools> = {
+	'x-tao-option-zoom': 'zoom',
+	'x-tao-option-highlighter': 'highlighter',
+	'x-tao-option-calculator': 'calculator',
+	'x-tao-option-reviewScreen': 'reviewScreen',
+	'x-tao-option-markReview': 'markReview',
+	'x-tao-option-endTestWarning': 'endTestWarning',
+	'x-tao-option-nextPartWarning': 'nextPartWarning'
+};
+
+export const TOOL_LABELS: Record<string, string> = {
+	zoom: 'Zoom',
+	highlighter: 'Surlignage',
+	calculator: 'Calculatrice',
+	reviewScreen: 'Révision',
+	markReview: 'Marquer',
+	endTestWarning: 'Avertissement fin',
+	nextPartWarning: 'Avertissement partie'
+};
+
+export function parseCategory(category: string | null): { tools: TaoTools; informational: boolean } {
+	if (!category) return { tools: {}, informational: false };
+	const parts = category.split(/\s+/);
+	const tools: TaoTools = {};
+	let informational = false;
+	for (const part of parts) {
+		if (part === 'x-tao-itemusage-informational') {
+			informational = true;
+		} else {
+			const key = CATEGORY_TO_TOOL[part];
+			if (key) tools[key] = true;
+		}
+	}
+	return { tools, informational };
+}
+
+export function mergeTools(a: TaoTools, b: TaoTools): TaoTools {
+	const result: TaoTools = { ...a };
+	for (const key of Object.keys(b)) {
+		if (b[key]) result[key] = true;
+	}
+	return result;
+}

--- a/mono/src/lib/questions/types.ts
+++ b/mono/src/lib/questions/types.ts
@@ -1,0 +1,134 @@
+export type ItemType =
+	| 'instruction'
+	| 'single-choice'
+	| 'multiple-choice'
+	| 'text'
+	| 'matching'
+	| 'ordering'
+	| 'custom'
+	| 'unknown';
+
+export interface RichContent {
+	html?: string;
+	text?: string;
+}
+
+export interface TimeLimits {
+	minTime?: number;
+	maxTime?: number;
+}
+
+export interface TaoTools {
+	zoom?: boolean;
+	highlighter?: boolean;
+	calculator?: boolean;
+	reviewScreen?: boolean;
+	markReview?: boolean;
+	endTestWarning?: boolean;
+	nextPartWarning?: boolean;
+	[key: string]: boolean | undefined;
+}
+
+export interface Assessment {
+	id: string;
+	title: string;
+	language?: string;
+	metadata: AssessmentMetadata;
+	sections: Section[];
+	assets: Record<string, Asset>;
+}
+
+export interface AssessmentMetadata {
+	source?: string;
+	toolName?: string;
+	toolVersion?: string;
+	navigationMode?: 'linear' | 'nonlinear';
+	submissionMode?: 'individual' | 'simultaneous';
+	timeLimits?: TimeLimits;
+	tools: TaoTools;
+}
+
+export interface Section {
+	id: string;
+	title: string;
+	testPart?: string;
+	timeLimits?: TimeLimits;
+	items: AssessmentItem[];
+}
+
+export interface AssessmentItem {
+	id: string;
+	title: string;
+	label?: string;
+	type: ItemType;
+	content: RichContent;
+	responses?: ResponseDefinition[];
+	scoring?: Scoring;
+	feedback?: Feedback[];
+	assets?: string[];
+	metadata?: ItemMetadata;
+}
+
+export interface ItemMetadata {
+	tools?: TaoTools;
+	informational?: boolean;
+	competency?: string;
+	indicator?: string;
+	competencyDescr?: string;
+	masteryDescr?: string;
+	sourceRow?: number;
+	[k: string]: unknown;
+}
+
+export interface ResponseDefinition {
+	id: string;
+	cardinality: 'single' | 'multiple' | 'ordered';
+	baseType: 'identifier' | 'string' | 'integer' | 'float';
+	correctAnswers?: string[];
+	options?: ChoiceOption[];
+	mapping?: Record<string, number>;
+	constraints?: ResponseConstraints;
+}
+
+export interface ResponseConstraints {
+	maxLength?: number;
+	minChoices?: number;
+	maxChoices?: number;
+}
+
+export interface ChoiceOption {
+	id: string;
+	content: RichContent;
+	correct?: boolean;
+}
+
+export interface Scoring {
+	maxScore?: number;
+	rules?: ScoreRule[];
+}
+
+export interface ScoreRule {
+	answerId: string;
+	score: number;
+}
+
+export interface Feedback {
+	id: string;
+	title?: string;
+	content: RichContent;
+}
+
+export interface Asset {
+	id: string;
+	type: 'image' | 'pdf' | 'video' | 'css' | 'other';
+	path: string;
+	blob?: Blob;
+	originalName?: string;
+}
+
+export interface AssessmentDatabase {
+	assessment: Omit<Assessment, 'sections' | 'assets'>;
+	items: Record<string, AssessmentItem>;
+	sections: Record<string, Section>;
+	assets: Record<string, Asset>;
+}

--- a/mono/src/routes/export/+page.svelte
+++ b/mono/src/routes/export/+page.svelte
@@ -76,9 +76,27 @@
   }
 
   function isItemVisible(itemId: string, itemType: string): boolean {
-    if (itemType === 'instruction' && !$showInstruction) return false;
+    if (itemType === 'instruction' && !$showInstruction) {
+      return $showItems.get(itemId) === true;
+    }
     return $showItems.get(itemId) !== false;
   }
+
+  $effect(() => {
+    const visible = $showInstruction;
+    const items = $activeItems;
+    const map = new Map($showItems);
+    let changed = false;
+    for (const item of items) {
+      if (item.type !== 'instruction') continue;
+      if (!visible) {
+        if (map.get(item.id) !== false) { map.set(item.id, false); changed = true; }
+      } else {
+        if (map.has(item.id)) { map.delete(item.id); changed = true; }
+      }
+    }
+    if (changed) showItems.set(map);
+  });
 
   $effect(() => {
     sidebarEnabled.set(true);

--- a/mono/src/routes/export/+page.svelte
+++ b/mono/src/routes/export/+page.svelte
@@ -14,11 +14,14 @@
     compareExamIndex1,
     compareExamIndex2,
     showMenu,
-    questions,
+    activeItems,
+    showItems,
+    showInstruction,
     inzage,
     zoom,
     multiple,
-    exams,
+    assessments,
+    examsIndex,
     windowName,
     randomizeQuestion,
     randomizeAnswer,
@@ -27,12 +30,14 @@
     showLetter,
     currentPage,
   } from "$lib/export/store";
+  import { JsonAdapter } from "$lib/questions/adapters/json.js";
+  import ExamToolsBadge from "$lib/questions/ExamToolsBadge.svelte";
   import ChangelogModal from "$lib/export/ChangelogModal.svelte";
   import DocumentationModal from "$lib/export/DocumentationModal.svelte";
 
   import { get } from "svelte/store";
-  
-  
+
+
   let titleHeader = $state("");
   let rrnHeader = $state("");
   let showChangelog = $state(false);
@@ -45,48 +50,13 @@
     if ($showChangelogStore) { showChangelog = true; showChangelogStore.set(false); }
   });
 
-  function exportToJson() {
-    const data = {
-      title: titleHeader || "Exported Questions",
-      rrn: rrnHeader || "",
-      questions: get(questions).map(q => {
-        const promptArray = Array.isArray(q.prompt)
-          ? q.prompt
-          : q.prompt && typeof (q.prompt as any).length === 'number'
-          ? Array.from(q.prompt as any)
-          : [q.prompt as any];
-
-        return {
-          title: q.title,
-          type: q.type,
-          prompt: promptArray
-            .map((el) => (el && (el as Element).outerHTML ? (el as Element).outerHTML : String(el)))
-            .join(''),
-          answers: q.answers.map((a) => ({
-            text: a.txt,
-            points: a.point,
-            id: a.id,
-            correct: a.correct,
-          })),
-          maxLength: q.maxLenght || [],
-          show: q.show,
-        };
-      }),
-
-      mappings: {
-        questionMapping: get(questionMapping),
-        answerMapping: get(answerMapping)
-      },
-      settings: {
-        randomizeQuestion: get(randomizeQuestion),
-        randomizeAnswer: get(randomizeAnswer),
-        showLetter: get(showLetter),
-        zoom: get(zoom),
-        inzage: get(inzage)
-      }
-    };
-
-    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+  async function exportToJson() {
+    const list = get(assessments);
+    const index = get(examsIndex);
+    const assessment = list[index];
+    if (!assessment) return;
+    const adapter = new JsonAdapter();
+    const blob = await adapter.write(assessment);
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
@@ -101,25 +71,13 @@
     window.print();
   }
 
-  function toggleQuestion(index: number, show: boolean) {
-    questions.update((o) =>
-      o.map((q, i) => (i === index ? { ...q, show } : q)),
-    );
+  function toggleItemShow(itemId: string, show: boolean) {
+    showItems.update(m => { const u = new Map(m); u.set(itemId, show); return u; });
   }
 
-  function toggleExamQuestion(examIndex: number, index: number, show: boolean) {
-    exams.update((list) =>
-      list.map((ex, ei) =>
-        ei === examIndex
-          ? {
-              ...ex,
-              questions: ex.questions.map((q, i) =>
-                i === index ? { ...q, show } : q,
-              ),
-            }
-          : ex,
-      ),
-    );
+  function isItemVisible(itemId: string, itemType: string): boolean {
+    if (itemType === 'instruction' && !$showInstruction) return false;
+    return $showItems.get(itemId) !== false;
   }
 
   $effect(() => {
@@ -159,30 +117,30 @@
       {#if $currentPage === 'audit'}
         <!-- Audit View -->
         <AuditTab />
-      {:else if $currentPage === 'compare' && $multiple && $exams.length > 1 && $compareExamIndex1 >= 0 && $compareExamIndex2 >= 0}
+      {:else if $currentPage === 'compare' && $multiple && $assessments.length > 1 && $compareExamIndex1 >= 0 && $compareExamIndex2 >= 0}
         <div class="compare-wrapper">
           <!-- Exam Selector -->
           <div class="compare-selector hide-print">
             <div class="selector-group">
               <label for="exam-select-1">Test A:</label>
               <select id="exam-select-1" bind:value={$compareExamIndex1} class="exam-select">
-                {#each $exams as exam, i}
-                  <option value={i}>{exam.name || `Exam ${i + 1}`}</option>
+                {#each $assessments as a, i}
+                  <option value={i}>{a.title || `Exam ${i + 1}`}</option>
                 {/each}
               </select>
             </div>
             <div class="selector-group">
               <label for="exam-select-2">Test B:</label>
               <select id="exam-select-2" bind:value={$compareExamIndex2} class="exam-select">
-                {#each $exams as exam, i}
-                  <option value={i}>{exam.name || `Exam ${i + 1}`}</option>
+                {#each $assessments as a, i}
+                  <option value={i}>{a.title || `Exam ${i + 1}`}</option>
                 {/each}
               </select>
             </div>
           </div>
-          
+
           <div class="compare-column">
-            <div class="compare-label">{$exams[$compareExamIndex1]?.name || `Test A`}</div>
+            <div class="compare-label">{$assessments[$compareExamIndex1]?.title || `Test A`}</div>
             <div class="questions-container" style="zoom:{$zoom};">
               {#if $inzage}
                 <div class="inzage-header hide-print">
@@ -194,16 +152,14 @@
                   </div>
                 </div>
               {/if}
-              {#each $exams[$compareExamIndex1]?.questions || [] as question, i}
-                <Question
-                  {question}
-                  onToggleShow={(show) => toggleExamQuestion($compareExamIndex1, i, show)}
-                />
+              {#each $assessments[$compareExamIndex1]?.sections.flatMap(s => s.items) ?? [] as item}
+                {@const show = isItemVisible(item.id, item.type)}
+                <Question {item} {show} onToggleShow={(s) => toggleItemShow(item.id, s)} />
               {/each}
             </div>
           </div>
           <div class="compare-column">
-            <div class="compare-label">{$exams[$compareExamIndex2]?.name || `Test B`}</div>
+            <div class="compare-label">{$assessments[$compareExamIndex2]?.title || `Test B`}</div>
             <div class="questions-container" style="zoom:{$zoom};">
               {#if $inzage}
                 <div class="inzage-header hide-print">
@@ -215,16 +171,14 @@
                   </div>
                 </div>
               {/if}
-              {#each $exams[$compareExamIndex2]?.questions || [] as question, i}
-                <Question
-                  {question}
-                  onToggleShow={(show) => toggleExamQuestion($compareExamIndex2, i, show)}
-                />
+              {#each $assessments[$compareExamIndex2]?.sections.flatMap(s => s.items) ?? [] as item}
+                {@const show = isItemVisible(item.id, item.type)}
+                <Question {item} {show} onToggleShow={(s) => toggleItemShow(item.id, s)} />
               {/each}
             </div>
           </div>
         </div>
-      {:else if $exams.length === 0}
+      {:else if $assessments.length === 0}
         <div class="dropzone-center">
           <EmptyState
             icon={FileArchive}
@@ -261,16 +215,23 @@
             </div>
           {/if}
 
-          {#if $questions.length > 0}
-            {#each $questions as question, i}
-              <Question
-                {question}
-                onToggleShow={(show) => toggleQuestion(i, show)}
-              />
+          {#if $activeItems.length > 0}
+            {@const activeAssessment = $assessments[$examsIndex]}
+            {#if activeAssessment}
+              <div class="exam-header hide-print">
+                <ExamToolsBadge
+                  tools={activeAssessment.metadata.tools}
+                  timeLimits={activeAssessment.metadata.timeLimits}
+                />
+              </div>
+            {/if}
+            {#each $activeItems as item}
+              {@const show = isItemVisible(item.id, item.type)}
+              <Question {item} {show} onToggleShow={(s) => toggleItemShow(item.id, s)} />
             {/each}
           {/if}
-           
-          {#if ($randomizeQuestion || $randomizeAnswer) && $questions.length > 0}
+
+          {#if ($randomizeQuestion || $randomizeAnswer) && $activeItems.length > 0}
             <div class="mapping-table">
               <h3>Mapping</h3>
               <table class="mapping-main-table">
@@ -285,7 +246,7 @@
                   </tr>
                 </thead>
                 <tbody>
-                  {#each $questionMapping.filter((m: { type: string }) => m.type !== 'Instruction' && m.type !== 'Instruction QCM' && m.type !== 'Instruction QO') as qm, i}
+                  {#each $questionMapping.filter((m: { type: string }) => m.type !== 'instruction') as qm}
                     {@const ansMap = $answerMapping.find((a: { title: string }) => a.title.trim() === qm.title.trim())?.mapping || []}
                     <tr>
                       {#if $randomizeQuestion}
@@ -409,6 +370,10 @@
   .questions-container {
     max-width: 1080px;
     margin: 0 auto;
+  }
+
+  .exam-header {
+    padding: 12px 0 4px;
   }
 
   .compare-wrapper {

--- a/mono/src/routes/import/+page.svelte
+++ b/mono/src/routes/import/+page.svelte
@@ -4,7 +4,7 @@
   import Menu from "$lib/import/Menu.svelte";
   import QuestionPreview from "$lib/export/template/Question.svelte";
   import { showAnswer } from "$lib/export/store";
-  import type { QuestionType } from "$lib/export/helper";
+  import type { AssessmentItem } from "$lib/questions/types.js";
   import DropZone from "$lib/import/Input/DropZone.svelte";
   import {
     alternative,
@@ -23,19 +23,19 @@
     titleColumn,
   } from "$lib/import/helper/store";
   import { QCM, Question } from "$lib/import/helper/question";
-  import { qcmsToQuestionTypes } from "$lib/import/helper/toQuestionType";
+  import { qcmsToAssessmentItems } from "$lib/import/helper/toQuestionType";
   import { sidebarEnabled, sidebarOpen } from "$lib/sidebar";
   import { EmptyState } from "$lib/ui";
   import { FileSpreadsheet } from "lucide-svelte";
 
   let questions = $state<QCM[]>([]);
-  let renderQuestions = $state<QuestionType[]>([]);
+  let renderItems = $state<AssessmentItem[]>([]);
+  let itemVisibility = $state<Map<string, boolean>>(new Map());
   let workbook = $state<XLSX.WorkBook | undefined>(undefined);
 
-  // Render the import preview with the same component the export route uses by
-  // adapting the parsed QCMs into the shared QuestionType model.
   $effect(() => {
-    renderQuestions = qcmsToQuestionTypes(questions);
+    renderItems = qcmsToAssessmentItems(questions);
+    itemVisibility = new Map();
   });
 
   // Keep the shared renderer's answer visibility in sync with the import-side
@@ -103,10 +103,12 @@
     <div class="main-area">
       {#if $file}
         <div class="questions-container">
-          {#each renderQuestions as question, i}
+          {#each renderItems as item}
+            {@const show = itemVisibility.get(item.id) !== false}
             <QuestionPreview
-              {question}
-              onToggleShow={(show) => (renderQuestions[i].show = show)}
+              {item}
+              {show}
+              onToggleShow={(s) => { itemVisibility.set(item.id, s); itemVisibility = new Map(itemVisibility); }}
             />
           {/each}
         </div>


### PR DESCRIPTION
## Summary
This PR introduces a comprehensive refactor of the assessment and question handling system, replacing the legacy `QuestionType` model with a standardized `Assessment` data model and implementing a pluggable adapter pattern for reading/writing different assessment formats (QTI, Excel, CSV, JSON).

## Key Changes

### New Assessment Type System
- Created `$lib/questions/types.ts` with standardized interfaces:
  - `Assessment`: Top-level container with metadata, sections, and assets
  - `AssessmentItem`: Individual question/item with type, content, responses, and scoring
  - `Section`: Grouping of items within an assessment
  - `ItemType`: Unified type system (`instruction`, `single-choice`, `multiple-choice`, `text`, `matching`, `ordering`, `custom`, `unknown`)
  - Supporting types for responses, scoring, metadata, and TAO tools

### Adapter Pattern Implementation
- Created `$lib/questions/adapters/base.ts` with `AssessmentAdapter` interface
- Implemented format-specific adapters:
  - `QtiAdapter`: Parses QTI 2.2 ZIP files with full support for test structure, items, assets, and TAO tools
  - `ExcelAdapter`: Reads/writes Excel files with configurable column mapping
  - `CsvAdapter`: Reads/writes CSV format with choice-based questions
  - `JsonAdapter`: Serializes/deserializes Assessment objects
- All adapters support `read()` and `write()` methods with configurable options

### Store Refactoring
- Renamed stores for clarity:
  - `exams` → `assessments` (now holds `Assessment[]`)
  - `questions` → `activeItems` (now holds `AssessmentItem[]`)
  - `oldQuestions` → `oldItems`
- Added `showItems` store: `Map<string, boolean>` for per-item visibility overrides
- Updated subscription logic to extract items from assessment sections
- Renamed internal tracking variables: `originalQuestionOrder` → `originalItemOrder`, etc.

### TAO Tools Support
- Created `$lib/questions/tao-tools.ts` with:
  - `TaoTools` interface for exam accessibility features (zoom, highlighter, calculator, etc.)
  - `parseCategory()` function to extract tools from QTI category attributes
  - `mergeTools()` function to combine tool configurations
  - `TOOL_LABELS` for UI display

### Component Updates
- Updated `Question.svelte` to accept `AssessmentItem` instead of `QuestionType`
- Updated `QCM.svelte` to work with new response structure
- Added `ExamToolsBadge.svelte` to display assessment tools and time limits
- Updated `Settings.svelte` and `Tables.svelte` to use `showItems` Map
- Refactored `ZipDropZone.svelte` to use `QtiAdapter`

### Helper Function Updates
- Updated `qcmToQuestionType()` → `qcmToAssessmentItem()` in import helper
- Updated audit conversion functions to work with new item structure
- Maintained backward compatibility in `helper.ts` for legacy `QuestionType` (with updated field types)

### UI/UX Improvements
- Simplified question sorting logic with cleaner type checking
- Improved item visibility toggling with Map-based approach
- Added support for instruction items with separate visibility control
- Better handling of item metadata and tools display

## Notable Implementation Details
- QTI adapter properly handles nested test structure (testParts → sections → items)
- Asset management with blob URL injection for images
- Proper normalization of file paths in ZIP entries
- Support for item-level and assessment-level tool configurations
- Maintains original item order tracking for randomization features

https://claude.ai/code/session_01F2xXNQbp5fHBqnHFquMYkp