### PR TITLE
Add Format module: bold question prompts in a TAO QTI export

### DIFF
--- a/mono/src/lib/format/__tests__/boldPrompt.test.ts
+++ b/mono/src/lib/format/__tests__/boldPrompt.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { boldPromptXml } from '../boldPrompt.js';
+
+const fixtures = join(import.meta.dir, 'fixtures');
+const read = (name: string) => readFileSync(join(fixtures, name), 'utf-8');
+
+describe('boldPromptXml', () => {
+  test('wraps a plain-text prompt to match a hand-bolded TAO export', () => {
+    const plain = read('plain.qti.xml');
+    const bold = read('bold.qti.xml');
+
+    const { xml, changed } = boldPromptXml(plain);
+
+    expect(changed).toBe(true);
+    expect(xml).toBe(bold);
+  });
+
+  test('produces a <strong> prompt padded with non-breaking-space divs', () => {
+    const input =
+      '          <prompt>Question text?</prompt>';
+    const { xml, changed } = boldPromptXml(input);
+
+    expect(changed).toBe(true);
+    expect(xml).toBe(
+      '          <prompt>\n' +
+        '            <div> </div>\n' +
+        '            <strong>Question text?</strong>\n' +
+        '            <div> </div>\n' +
+        '          </prompt>',
+    );
+  });
+
+  test('is idempotent: re-running leaves an already-bold prompt untouched', () => {
+    const bold = read('bold.qti.xml');
+    const { xml, changed } = boldPromptXml(bold);
+
+    expect(changed).toBe(false);
+    expect(xml).toBe(bold);
+  });
+
+  test('skips an empty prompt', () => {
+    const input = '  <prompt></prompt>';
+    const { xml, changed } = boldPromptXml(input);
+
+    expect(changed).toBe(false);
+    expect(xml).toBe(input);
+  });
+
+  test('skips a prompt that already contains markup (e.g. an image)', () => {
+    const input = '  <prompt><img src="x.png"/></prompt>';
+    const { xml, changed } = boldPromptXml(input);
+
+    expect(changed).toBe(false);
+    expect(xml).toBe(input);
+  });
+
+  test('preserves every other byte of the document', () => {
+    const plain = read('plain.qti.xml');
+    const { xml } = boldPromptXml(plain);
+
+    // The closing assessment tag and the response mapping are untouched.
+    expect(xml).toContain('</assessmentItem>');
+    expect(xml).toContain('<mapEntry mapKey="choice_1" mappedValue="3"/>');
+    // The original single-line prompt no longer exists.
+    expect(xml).not.toContain('<prompt>In welke');
+  });
+});

--- a/mono/src/lib/format/__tests__/fixtures/bold.qti.xml
+++ b/mono/src/lib/format/__tests__/fixtures/bold.qti.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assessmentItem xmlns="http://www.imsglobal.org/xsd/imsqti_v2p2" xmlns:m="http://www.w3.org/1998/Math/MathML" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p2 http://www.imsglobal.org/xsd/qti/qtiv2p2/imsqti_v2p2.xsd" identifier="i6011423ba1e83975c19a3f96e48f662" title="MKV 01" label="MKV 01" xml:lang="nl-NL" adaptive="false" timeDependent="false" toolName="TAO" toolVersion="2024.11 LTS">
+  <responseDeclaration identifier="RESPONSE" cardinality="single" baseType="identifier">
+    <correctResponse>
+      <value><![CDATA[choice_1]]></value>
+    </correctResponse>
+    <mapping defaultValue="0">
+      <mapEntry mapKey="choice_1" mappedValue="3"/>
+      <mapEntry mapKey="choice_2" mappedValue="-1"/>
+      <mapEntry mapKey="choice_3" mappedValue="-1"/>
+      <mapEntry mapKey="choice_4" mappedValue="-1"/>
+    </mapping>
+  </responseDeclaration>
+  <outcomeDeclaration identifier="SCORE" cardinality="single" baseType="float" normalMaximum="3"/>
+  <outcomeDeclaration identifier="MAXSCORE" cardinality="single" baseType="float">
+    <defaultValue>
+      <value>3</value>
+    </defaultValue>
+  </outcomeDeclaration>
+  <itemBody>
+    <div class="grid-row">
+      <div class="col-12">
+        <choiceInteraction responseIdentifier="RESPONSE" shuffle="true" maxChoices="1" minChoices="0" orientation="vertical">
+          <prompt>
+            <div> </div>
+            <strong>In welke van de onderstaande gevallen moet de Algemene Administratie van de Douane en Accijnzen (AADA) NIET het recht om gehoord toepassen als ze een beschikking neemt?</strong>
+            <div> </div>
+          </prompt>
+          <simpleChoice identifier="choice_1" fixed="false" showHide="show">Wanneer er een beschikking genomen wordt in verband met het verlenen van een Bindende Tarief Inlichting.</simpleChoice>
+          <simpleChoice identifier="choice_2" fixed="false" showHide="show">Wanneer zij een beschikking neemt in verband met een aanvraag tot terugbetaling van invoerrechten.</simpleChoice>
+          <simpleChoice identifier="choice_3" fixed="false" showHide="show">Wanneer zij een beschikking neemt in verband de oorsprong van de goederen en de hiermee verband houdende invoerrechten.</simpleChoice>
+          <simpleChoice identifier="choice_4" fixed="false" showHide="show">Wanneer zij een beschikking neemt tot het weigeren van een vergunning voor een douane-entrepot.</simpleChoice>
+        </choiceInteraction>
+      </div>
+    </div>
+  </itemBody>
+  <responseProcessing template="http://www.imsglobal.org/question/qti_v2p2/rptemplates/map_response"/>
+</assessmentItem>

--- a/mono/src/lib/format/__tests__/fixtures/plain.qti.xml
+++ b/mono/src/lib/format/__tests__/fixtures/plain.qti.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assessmentItem xmlns="http://www.imsglobal.org/xsd/imsqti_v2p2" xmlns:m="http://www.w3.org/1998/Math/MathML" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p2 http://www.imsglobal.org/xsd/qti/qtiv2p2/imsqti_v2p2.xsd" identifier="i6011423ba1e83975c19a3f96e48f662" title="MKV 01" label="MKV 01" xml:lang="nl-NL" adaptive="false" timeDependent="false" toolName="TAO" toolVersion="2024.11 LTS">
+  <responseDeclaration identifier="RESPONSE" cardinality="single" baseType="identifier">
+    <correctResponse>
+      <value><![CDATA[choice_1]]></value>
+    </correctResponse>
+    <mapping defaultValue="0">
+      <mapEntry mapKey="choice_1" mappedValue="3"/>
+      <mapEntry mapKey="choice_2" mappedValue="-1"/>
+      <mapEntry mapKey="choice_3" mappedValue="-1"/>
+      <mapEntry mapKey="choice_4" mappedValue="-1"/>
+    </mapping>
+  </responseDeclaration>
+  <outcomeDeclaration identifier="SCORE" cardinality="single" baseType="float" normalMaximum="3"/>
+  <outcomeDeclaration identifier="MAXSCORE" cardinality="single" baseType="float">
+    <defaultValue>
+      <value>3</value>
+    </defaultValue>
+  </outcomeDeclaration>
+  <itemBody>
+    <div class="grid-row">
+      <div class="col-12">
+        <choiceInteraction responseIdentifier="RESPONSE" shuffle="true" maxChoices="1" minChoices="0" orientation="vertical">
+          <prompt>In welke van de onderstaande gevallen moet de Algemene Administratie van de Douane en Accijnzen (AADA) NIET het recht om gehoord toepassen als ze een beschikking neemt?</prompt>
+          <simpleChoice identifier="choice_1" fixed="false" showHide="show">Wanneer er een beschikking genomen wordt in verband met het verlenen van een Bindende Tarief Inlichting.</simpleChoice>
+          <simpleChoice identifier="choice_2" fixed="false" showHide="show">Wanneer zij een beschikking neemt in verband met een aanvraag tot terugbetaling van invoerrechten.</simpleChoice>
+          <simpleChoice identifier="choice_3" fixed="false" showHide="show">Wanneer zij een beschikking neemt in verband de oorsprong van de goederen en de hiermee verband houdende invoerrechten.</simpleChoice>
+          <simpleChoice identifier="choice_4" fixed="false" showHide="show">Wanneer zij een beschikking neemt tot het weigeren van een vergunning voor een douane-entrepot.</simpleChoice>
+        </choiceInteraction>
+      </div>
+    </div>
+  </itemBody>
+  <responseProcessing template="http://www.imsglobal.org/question/qti_v2p2/rptemplates/map_response"/>
+</assessmentItem>

--- a/mono/src/lib/format/boldPrompt.ts
+++ b/mono/src/lib/format/boldPrompt.ts
@@ -1,0 +1,72 @@
+/**
+ * Bold-prompt formatter — pure XML transform (no dependencies).
+ *
+ * TAO exports each question as a `qti.xml` file. When a prompt is authored as
+ * plain text it renders as plain text in the test player. The test team wants
+ * the question prompt to stand out, which TAO encodes by wrapping the prompt
+ * text in `<strong>` and padding it with a blank line above and below:
+ *
+ *   <prompt>Question text?</prompt>
+ *
+ * becomes
+ *
+ *   <prompt>
+ *     <div>&#160;</div>
+ *     <strong>Question text?</strong>
+ *     <div>&#160;</div>
+ *   </prompt>
+ *
+ * The blank lines are `<div>` elements containing a single non-breaking space
+ * (U+00A0), exactly as TAO produces them when you bold a prompt by hand.
+ *
+ * The transform is intentionally surgical: it rewrites only the `<prompt>`
+ * region of the XML string and leaves every other byte untouched, so the
+ * re-zipped package still imports cleanly into TAO. Prompts that already
+ * contain markup (a previously bolded prompt, an image, formatted text, …) are
+ * left as-is, which makes the operation safe to run more than once.
+ */
+
+/** The non-breaking space (U+00A0) TAO places inside the spacer divs. */
+const NBSP = '\u00A0';
+
+/** Matches a `<prompt>…</prompt>` block, capturing its leading indentation. */
+const PROMPT_RE = /([ \t]*)<prompt>([\s\S]*?)<\/prompt>/g;
+
+export interface BoldPromptResult {
+  /** The (possibly) transformed XML. */
+  xml: string;
+  /** Whether anything was changed. */
+  changed: boolean;
+}
+
+/**
+ * Wrap the plain-text prompt of a single qti.xml document in `<strong>`.
+ *
+ * Returns the transformed XML and whether a change was made. Prompts that are
+ * empty or already contain child elements are skipped.
+ */
+export function boldPromptXml(xml: string): BoldPromptResult {
+  let changed = false;
+
+  const out = xml.replace(PROMPT_RE, (match, indent: string, inner: string) => {
+    const text = inner.trim();
+
+    // Skip empty prompts and prompts that already carry markup (already bold,
+    // contain an image, etc.). A plain-text prompt never contains '<'.
+    if (text.length === 0 || text.includes('<')) {
+      return match;
+    }
+
+    changed = true;
+    const pad = `${indent}  `;
+    return (
+      `${indent}<prompt>\n` +
+      `${pad}<div>${NBSP}</div>\n` +
+      `${pad}<strong>${text}</strong>\n` +
+      `${pad}<div>${NBSP}</div>\n` +
+      `${indent}</prompt>`
+    );
+  });
+
+  return { xml: out, changed };
+}

--- a/mono/src/lib/format/boldPromptZip.ts
+++ b/mono/src/lib/format/boldPromptZip.ts
@@ -1,0 +1,59 @@
+import {
+  ZipReader,
+  ZipWriter,
+  BlobReader,
+  BlobWriter,
+  TextReader,
+  TextWriter,
+} from '@zip.js/zip.js';
+import { boldPromptXml } from './boldPrompt';
+
+export interface BoldPromptZipResult {
+  /** The rebuilt ZIP package, ready to download / re-upload to TAO. */
+  blob: Blob;
+  /** Number of qti.xml files found in the package. */
+  total: number;
+  /** Number of qti.xml files whose prompt was bolded. */
+  changed: number;
+}
+
+/**
+ * Read a TAO QTI ZIP package, bold every plain-text question prompt, and
+ * return a new ZIP with the same structure. Non-`qti.xml` entries (the
+ * manifest, images, …) are copied through unchanged so the package still
+ * imports back into TAO.
+ */
+export async function boldPromptZip(
+  input: Blob | File,
+): Promise<BoldPromptZipResult> {
+  const reader = new ZipReader(new BlobReader(input));
+  const writer = new ZipWriter(new BlobWriter('application/zip'));
+
+  let total = 0;
+  let changed = 0;
+
+  try {
+    const entries = await reader.getEntries();
+
+    for (const entry of entries) {
+      // Directories are recreated implicitly from file paths.
+      if (entry.directory || !entry.getData) continue;
+
+      if (entry.filename.endsWith('qti.xml')) {
+        total += 1;
+        const xml = await entry.getData(new TextWriter());
+        const result = boldPromptXml(xml);
+        if (result.changed) changed += 1;
+        await writer.add(entry.filename, new TextReader(result.xml));
+      } else {
+        const blob = await entry.getData(new BlobWriter());
+        await writer.add(entry.filename, new BlobReader(blob));
+      }
+    }
+  } finally {
+    await reader.close();
+  }
+
+  const blob = await writer.close();
+  return { blob, total, changed };
+}

--- a/mono/src/routes/+layout.svelte
+++ b/mono/src/routes/+layout.svelte
@@ -47,6 +47,7 @@
 		"/export": "export",
 		"/import": "import",
 		"/forge": "forge",
+		"/format": "format",
 		"/iat": "iat",
 		"/audit": "audit",
 	};

--- a/mono/src/routes/+page.svelte
+++ b/mono/src/routes/+page.svelte
@@ -9,6 +9,7 @@
     Upload,
     Download,
     Hammer,
+    Bold,
     ClipboardCheck,
     Library,
     ScanSearch,
@@ -83,6 +84,14 @@
       eyebrow: 'ZIP to PDF/JSON',
       description: 'Load ZIP exam archives, configure settings, preview questions and answers, and export formatted result tables.',
       icon: Download,
+      available: true,
+    },
+    {
+      path: '/format',
+      title: 'Format',
+      eyebrow: 'Bold prompts',
+      description: 'Upload a TAO QTI export and get the same ZIP back with every question prompt wrapped in bold, ready to re-import.',
+      icon: Bold,
       available: true,
     },
     {

--- a/mono/src/routes/format/+page.svelte
+++ b/mono/src/routes/format/+page.svelte
@@ -1,0 +1,303 @@
+<script lang="ts">
+  import { Bold, FileArchive, Download, Wand2, CheckCircle2 } from "lucide-svelte";
+  import { EmptyState, SidebarLayout, PageHeader, FileInput, Button } from "$lib/ui";
+  import { pushError, pushNotification } from "$lib/ui/notifications";
+  import { boldPromptZip, type BoldPromptZipResult } from "$lib/format/boldPromptZip";
+
+  const SITE_URL = "https://tao.lv0.eu";
+  const PAGE_TITLE = "Format — TAO";
+  const PAGE_DESC =
+    "Bold every question prompt in a TAO QTI export: upload the ZIP, get a new ZIP back, re-import it into TAO.";
+
+  let files = $state<File[]>([]);
+  let processing = $state(false);
+  let result = $state<BoldPromptZipResult | null>(null);
+  let outName = $state("");
+
+  const sourceFile = $derived(files[0] ?? null);
+
+  function onFiles(selected: File[]) {
+    files = selected;
+    result = null;
+  }
+
+  function clearFile() {
+    files = [];
+    result = null;
+  }
+
+  /** Append "-bold" before the .zip extension. */
+  function boldName(name: string): string {
+    return name.replace(/(\.zip)?$/i, "") + "-bold.zip";
+  }
+
+  async function run() {
+    if (!sourceFile || processing) return;
+    processing = true;
+    result = null;
+    try {
+      const res = await boldPromptZip(sourceFile);
+      result = res;
+      outName = boldName(sourceFile.name);
+      pushNotification({
+        title: "Prompts formatted",
+        message:
+          res.changed === 0
+            ? `No plain-text prompts to bold across ${res.total} question${res.total === 1 ? "" : "s"}.`
+            : `Bolded ${res.changed} of ${res.total} question prompt${res.total === 1 ? "" : "s"}.`,
+        variant: res.changed === 0 ? "info" : "success",
+      });
+    } catch (err) {
+      pushError(
+        "Could not process the ZIP",
+        err instanceof Error ? err.message : "The file is not a valid TAO QTI package.",
+      );
+    } finally {
+      processing = false;
+    }
+  }
+
+  function download() {
+    if (!result) return;
+    const url = URL.createObjectURL(result.blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = outName || "formatted-bold.zip";
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }
+</script>
+
+<svelte:head>
+  <title>{PAGE_TITLE}</title>
+  <meta name="description" content={PAGE_DESC} />
+  <link rel="canonical" href={`${SITE_URL}/format`} />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="TAO" />
+  <meta property="og:title" content={PAGE_TITLE} />
+  <meta property="og:description" content={PAGE_DESC} />
+  <meta property="og:url" content={`${SITE_URL}/format`} />
+  <meta property="og:image" content={`${SITE_URL}/og-image.png`} />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content={PAGE_TITLE} />
+  <meta name="twitter:description" content={PAGE_DESC} />
+  <meta name="twitter:image" content={`${SITE_URL}/og-image.png`} />
+</svelte:head>
+
+<SidebarLayout sidebarLabel="Format options">
+  {#snippet sidebar()}
+    <div class="panel">
+      <h2 class="panel-title">Source package</h2>
+      <FileInput
+        accept=".zip"
+        invalidTitle="Unsupported file"
+        bind:file={files}
+        onfiles={onFiles}
+      />
+
+      {#if sourceFile}
+        <div class="file-badge">
+          <FileArchive size={15} />
+          <span class="file-name" title={sourceFile.name}>{sourceFile.name}</span>
+        </div>
+
+        <Button variant="primary" disabled={processing} onclick={run}>
+          <Wand2 size={16} />
+          {processing ? "Formatting…" : "Bold prompts"}
+        </Button>
+
+        {#if result}
+          <Button variant="secondary" onclick={download}>
+            <Download size={16} />
+            Download ZIP
+          </Button>
+          <button type="button" class="link-btn" onclick={clearFile}>
+            Choose another file
+          </button>
+        {/if}
+      {/if}
+    </div>
+  {/snippet}
+
+  <main class="main">
+    <PageHeader
+      icon={Bold}
+      eyebrow="Bold prompts"
+      title="Format"
+      subtitle="Wrap every plain-text question prompt of a TAO export in bold, then re-import the ZIP."
+    />
+
+    {#if !sourceFile}
+      <EmptyState
+        icon={FileArchive}
+        title="Upload a TAO QTI export"
+        description="Pick the .zip you exported from TAO. Each question's prompt is wrapped in bold and the package is rebuilt unchanged otherwise — ready to import straight back into TAO."
+      />
+    {:else if result}
+      <section class="result-card">
+        <div class="result-head">
+          <span class="result-icon"><CheckCircle2 size={20} /></span>
+          <div>
+            <h3 class="result-title">
+              {result.changed === 0
+                ? "Nothing to format"
+                : `${result.changed} prompt${result.changed === 1 ? "" : "s"} bolded`}
+            </h3>
+            <p class="result-sub">
+              {result.total} question{result.total === 1 ? "" : "s"} in the package
+              {#if result.changed > 0 && result.changed < result.total}
+                · {result.total - result.changed} already formatted or skipped
+              {/if}
+            </p>
+          </div>
+        </div>
+
+        <p class="result-note">
+          Download <code>{outName}</code> and import it back into TAO to get the
+          formatted questions automatically.
+        </p>
+
+        <Button variant="primary" onclick={download}>
+          <Download size={16} />
+          Download {outName}
+        </Button>
+      </section>
+    {:else}
+      <section class="result-card">
+        <h3 class="result-title">Ready to format</h3>
+        <p class="result-note">
+          <strong>{sourceFile.name}</strong> is loaded. Press
+          <strong>Bold prompts</strong> in the side panel to wrap each question
+          prompt in bold and rebuild the ZIP.
+        </p>
+      </section>
+    {/if}
+  </main>
+</SidebarLayout>
+
+<style>
+  .main {
+    padding: 1.5rem;
+    max-width: 900px;
+    margin: 0 auto;
+    width: 100%;
+  }
+
+  .panel {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .panel-title {
+    margin: 0;
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+  }
+
+  .file-badge {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 10px;
+    background: var(--surface-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    color: var(--text);
+  }
+
+  .file-name {
+    flex: 1;
+    min-width: 0;
+    font-size: 13px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .link-btn {
+    align-self: flex-start;
+    background: none;
+    border: none;
+    padding: 2px;
+    color: var(--text-muted);
+    font-size: 12px;
+    cursor: pointer;
+    text-decoration: underline;
+  }
+
+  .link-btn:hover {
+    color: var(--text);
+  }
+
+  .result-card {
+    margin-top: 1.25rem;
+    padding: 1.25rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-xl);
+    background: var(--surface-elevated);
+    box-shadow: var(--shadow-sm);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .result-head {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  .result-icon {
+    display: grid;
+    place-items: center;
+    width: 40px;
+    height: 40px;
+    flex-shrink: 0;
+    border-radius: var(--radius-lg);
+    color: var(--brand);
+    background: rgba(var(--brand-rgb), 0.08);
+    border: 1px solid rgba(var(--brand-rgb), 0.25);
+  }
+
+  .result-title {
+    margin: 0;
+    font-size: 1.05rem;
+    font-weight: 650;
+    color: var(--text);
+  }
+
+  .result-sub {
+    margin: 0.2rem 0 0;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+  }
+
+  .result-note {
+    margin: 0;
+    font-size: 0.9rem;
+    line-height: 1.6;
+    color: var(--text-muted);
+  }
+
+  .result-note code {
+    font-family: "SF Mono", "Roboto Mono", ui-monospace, monospace;
+    font-size: 0.82em;
+    padding: 0.1rem 0.35rem;
+    border-radius: var(--radius);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    color: var(--text);
+  }
+
+  @media (max-width: 640px) {
+    .main {
+      padding: 1rem;
+    }
+  }
+</style>

--- a/mono/static/sitemap.xml
+++ b/mono/static/sitemap.xml
@@ -19,6 +19,12 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://tao.lv0.eu/format</loc>
+    <lastmod>2026-06-29</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://tao.lv0.eu/forge</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>monthly</changefreq>


### PR DESCRIPTION
Adds a new /format tool that takes a TAO QTI ZIP, wraps every plain-text question <prompt> in <strong> (padded with non-breaking-space <div> spacers, matching how TAO encodes a hand-bolded prompt), and rebuilds the ZIP unchanged otherwise so it imports straight back into TAO.

- src/lib/format/boldPrompt.ts: pure, dependency-free XML transform (surgical regex on the <prompt> region; skips empty/already-formatted prompts, so it is idempotent)
- src/lib/format/boldPromptZip.ts: zip.js read/transform/rebuild
- src/routes/format/+page.svelte: SidebarLayout UI (upload, format, download), following the TAO design system
- Register the module on the home grid, layout breadcrumb and sitemap
- Unit tests cover the real NL -> bold fixture byte-for-byte


Claude-Session: https://claude.ai/code/session_0176MtcPmLzRttvUy3APx8zt