### PR TITLE
fix: audit parses Excel via Import pipeline, positional matching, unmatched=bloquant

### DIFF
--- a/mono/package.json
+++ b/mono/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "mono",
 	"private": true,
-	"version": "2.2.0",
+	"version": "2.3.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/mono/src/lib/audit/AuditConfig.svelte
+++ b/mono/src/lib/audit/AuditConfig.svelte
@@ -1,338 +1,50 @@
 <script lang="ts">
-  import { ChevronRight, CircleX } from 'lucide-svelte';
-  import { auditConfig } from './store';
-  import { PRESET_CONFIGS, validateConfig } from './config';
-  import type { ExcelConfig } from './types';
+  import { auditTemplate, auditIgnoreTitle } from './store';
+  import { TemplateColumn, bindingTemplate } from '$lib/import/helper/store';
 
-  type Props = {
-    availableSheets?: string[];
-    selectedSheet?: string;
-    onSheetChange?: (sheet: string) => void;
-  };
+  // The audit parses Excel with the exact same templates as the Import route, so
+  // a file that imports cleanly audits cleanly. "OTHER" is omitted because it has
+  // no column/row defaults to parse with.
+  const templates: TemplateColumn[] = [
+    TemplateColumn.FIN,
+    TemplateColumn.OLD_BOSA,
+    TemplateColumn.OLD_FIN,
+  ];
 
-  let { availableSheets = [], selectedSheet = '', onSheetChange = () => {} }: Props = $props();
-
-  let showAdvanced = $state(false);
-  let configErrors = $state<string[]>([]);
-
-  function updateConfig(updates: Partial<ExcelConfig>) {
-    const updated = { ...$auditConfig, ...updates };
-    const errors = validateConfig(updated);
-
-    if (errors.length === 0) {
-      auditConfig.set(updated);
-      configErrors = [];
-    } else {
-      configErrors = errors;
-    }
-  }
-
-  function applyPreset(name: string) {
-    const preset = PRESET_CONFIGS[name];
-    if (preset) {
-      auditConfig.set(preset);
-      configErrors = [];
-      showAdvanced = false;
-    }
-  }
-
-  function updateColumn(
-    columnType: keyof Omit<typeof $auditConfig.columns, 'answers' | 'answerMarker'>,
-    value: string
-  ) {
-    updateConfig({
-      columns: {
-        ...$auditConfig.columns,
-        [columnType]: value,
-      },
-    });
-  }
-
-  function updateAnswerColumn(index: number, value: string) {
-    if ($auditConfig.answerLayout === 'spread_columns' && Array.isArray($auditConfig.columns.answers)) {
-      const newAnswers = [...($auditConfig.columns.answers as string[])];
-      newAnswers[index] = value;
-      updateConfig({
-        columns: {
-          ...$auditConfig.columns,
-          answers: newAnswers,
-        },
-      });
-    }
-  }
-
-  function updateSingleAnswerColumn(value: string) {
-    updateConfig({
-      columns: {
-        ...$auditConfig.columns,
-        answers: value,
-      },
-    });
-  }
-
-  function updateAnswerLayout(layout: 'same_column' | 'spread_columns') {
-    const newColumns = { ...$auditConfig.columns };
-    
-    if (layout === 'same_column') {
-      // Convert from spread_columns to same_column
-      if (Array.isArray(newColumns.answers)) {
-        newColumns.answers = newColumns.answers[0] || 'G';
-      }
-      newColumns.answerMarker = 'G';
-    } else {
-      // Convert from same_column to spread_columns
-      if (typeof newColumns.answers === 'string') {
-        const baseCol = newColumns.answers;
-        const baseCols = ['G', 'H', 'I', 'J'];
-        newColumns.answers = baseCols;
-      }
-    }
-    
-    updateConfig({
-      answerLayout: layout,
-      columns: newColumns,
-    });
-  }
-
-  function updateAnswerMarker(value: string) {
-    updateConfig({
-      columns: {
-        ...$auditConfig.columns,
-        answerMarker: value,
-      },
-    });
-  }
+  const binding = $derived(bindingTemplate[$auditTemplate]);
+  const answerCols = $derived(`${binding.row.alternative} alt / row`);
 </script>
 
 <div class="config-section">
-  <!-- Preset Templates -->
-  <div class="presets">
-    <div style="display: none;">
-      <label for="preset-select">Select Template:</label>
-      <select id="preset-select" style="display: none;"></select>
-    </div>
-    <div class="preset-buttons" aria-label="Select template">
-      {#each Object.keys(PRESET_CONFIGS) as preset}
+  <div class="field">
+    <span class="field-label">Excel template</span>
+    <div class="preset-buttons" role="group" aria-label="Excel template">
+      {#each templates as template (template)}
         <button
+          type="button"
           class="preset-btn"
-          class:active={JSON.stringify($auditConfig) === JSON.stringify(PRESET_CONFIGS[preset])}
-          onclick={() => applyPreset(preset)}
+          class:active={$auditTemplate === template}
+          onclick={() => auditTemplate.set(template)}
         >
-          {preset}
+          {template}
         </button>
       {/each}
     </div>
+    <small>Same templates as the Import route — pick the one you imported with.</small>
   </div>
 
-  <!-- Sheet Selection -->
-  {#if availableSheets.length > 0}
-    <div class="settings-group">
-      <div class="input-group">
-        <label for="sheet-select">Excel Sheet:</label>
-        <select
-          id="sheet-select"
-          value={selectedSheet}
-          onchange={(e) => onSheetChange((e.target as HTMLSelectElement).value)}
-        >
-          {#each availableSheets as sheet}
-            <option value={sheet}>{sheet}</option>
-          {/each}
-        </select>
-        <small>Select which sheet contains the questions</small>
-      </div>
-    </div>
-  {/if}
+  <dl class="binding-summary">
+    <div><dt>Start row</dt><dd>{binding.row.offset + 1}</dd></div>
+    <div><dt>Alternatives</dt><dd>{answerCols}</dd></div>
+    <div><dt>Title col</dt><dd>{binding.column.title || '—'}</dd></div>
+    <div><dt>Prompt col</dt><dd>{binding.column.prompt || '—'}</dd></div>
+    <div><dt>Correct col</dt><dd>{binding.column.correct || 'first = correct'}</dd></div>
+  </dl>
 
-  <!-- Basic Settings -->
-  <div class="settings-group">
-    <div class="input-group">
-      <label for="rowOffset">Starting Row (0-based index):</label>
-      <input
-        id="rowOffset"
-        type="number"
-        min="0"
-        max="100"
-        value={$auditConfig.rowOffset}
-        onchange={(e) => updateConfig({ rowOffset: parseInt((e.target as HTMLInputElement).value) })}
-      />
-      <small>Excel row {$auditConfig.rowOffset + 1} is the first question</small>
-    </div>
-
-    <div class="input-group">
-      <label for="skipRows">Skip Rows Between Questions:</label>
-      <input
-        id="skipRows"
-        type="number"
-        min="0"
-        max="10"
-        value={$auditConfig.skipRows}
-        onchange={(e) => updateConfig({ skipRows: parseInt((e.target as HTMLInputElement).value) })}
-      />
-      <small>Number of blank/separator rows between questions (e.g., 1 for alternating blank rows)</small>
-    </div>
-
-    <div class="input-group">
-      <label for="altCount">Number of Answer Options:</label>
-      <input
-        id="altCount"
-        type="number"
-        min="1"
-        max="10"
-        value={$auditConfig.alternativeCount}
-        onchange={(e) => updateConfig({ alternativeCount: parseInt((e.target as HTMLInputElement).value) })}
-      />
-      <small>Typical value: 4</small>
-    </div>
-
-    <div class="input-group checkbox-group">
-      <label for="ignoreTitleMismatch">
-        <input
-          id="ignoreTitleMismatch"
-          type="checkbox"
-          checked={$auditConfig.ignoreTitleMismatch !== false}
-          onchange={(e) => updateConfig({ ignoreTitleMismatch: (e.target as HTMLInputElement).checked })}
-        />
-        <span>Ignore Title Mismatches</span>
-      </label>
-      <small>Skip comparison of question titles (recommended for old exports)</small>
-    </div>
-  </div>
-
-  <!-- Advanced: Column Mapping -->
-  <button class="toggle-btn" onclick={() => (showAdvanced = !showAdvanced)} aria-expanded={showAdvanced}>
-    <span class="chev" class:open={showAdvanced}><ChevronRight size={14} strokeWidth={2} /></span>
-    Column mapping (advanced)
-  </button>
-
-  {#if showAdvanced}
-    <div class="advanced-settings">
-      <p class="help-text">
-        Column letters should match Excel columns (A, B, C, ..., Z, AA, AB, etc.)
-      </p>
-
-      <div class="input-group">
-        <label for="answerLayout">Answer Layout:</label>
-        <select id="answerLayout" value={$auditConfig.answerLayout} onchange={(e) => updateAnswerLayout((e.target as HTMLSelectElement).value as 'same_column' | 'spread_columns')}>
-          <option value="same_column">Same Column (Q & A stacked vertically)</option>
-          <option value="spread_columns">Spread Columns (Q on one row, A across columns)</option>
-        </select>
-        <small>Choose how questions and answers are arranged in your Excel file</small>
-      </div>
-
-      <div class="input-group">
-        <label for="titleCol">Title Column (optional):</label>
-        <input
-          id="titleCol"
-          type="text"
-          maxlength="2"
-          value={$auditConfig.columns.title || ''}
-          onchange={(e) => updateColumn('title', (e.target as HTMLInputElement).value)}
-          placeholder="e.g., E"
-        />
-      </div>
-
-      <div class="input-group">
-        <label for="promptCol">Prompt/Question Column:</label>
-        <input
-          id="promptCol"
-          type="text"
-          maxlength="2"
-          value={$auditConfig.columns.prompt}
-          onchange={(e) => updateColumn('prompt', (e.target as HTMLInputElement).value)}
-          placeholder="e.g., F"
-        />
-      </div>
-
-      {#if $auditConfig.answerLayout === 'same_column'}
-        <div class="input-group">
-          <label for="answerCol">Answer Column:</label>
-          <input
-            id="answerCol"
-            type="text"
-            maxlength="2"
-            value={typeof $auditConfig.columns.answers === 'string' ? $auditConfig.columns.answers : 'F'}
-            onchange={(e) => updateSingleAnswerColumn((e.target as HTMLInputElement).value)}
-            placeholder="e.g., F"
-          />
-          <small>Column containing question and answer text (stacked vertically)</small>
-        </div>
-
-        <div class="input-group">
-          <label for="markerCol">Correct Answer Marker Column (optional):</label>
-          <input
-            id="markerCol"
-            type="text"
-            maxlength="2"
-            value={$auditConfig.columns.answerMarker || 'G'}
-            onchange={(e) => updateAnswerMarker((e.target as HTMLInputElement).value)}
-            placeholder="e.g., G"
-          />
-          <small>Column with X or x to mark the correct answer (e.g., old templates). If empty, first answer is assumed correct.</small>
-        </div>
-      {:else}
-        <div class="input-group">
-          <div style="display: block; margin-bottom: 8px; font-weight: 500; color: var(--text); font-size: 0.95em;">Answer Columns:</div>
-          <div class="answer-columns" role="group" aria-label="Answer column letters">
-            {#each $auditConfig.columns.answers as answer, i}
-              <input
-                type="text"
-                maxlength="2"
-                value={answer}
-                onchange={(e) => updateAnswerColumn(i, (e.target as HTMLInputElement).value)}
-                placeholder={`Answer ${i + 1}`}
-              />
-            {/each}
-          </div>
-          <small>Each answer in a separate column</small>
-        </div>
-      {/if}
-
-      <div class="input-group">
-        <label for="competencyCol">Competency Column (optional):</label>
-        <input
-          id="competencyCol"
-          type="text"
-          maxlength="2"
-          value={$auditConfig.columns.competency || ''}
-          onchange={(e) => updateColumn('competency', (e.target as HTMLInputElement).value)}
-          placeholder="e.g., A"
-        />
-      </div>
-
-      <div class="input-group">
-        <label for="dimensionCol">Dimension Column (optional):</label>
-        <input
-          id="dimensionCol"
-          type="text"
-          maxlength="2"
-          value={$auditConfig.columns.dimension || ''}
-          onchange={(e) => updateColumn('dimension', (e.target as HTMLInputElement).value)}
-          placeholder="e.g., B"
-        />
-      </div>
-
-      <div class="input-group">
-        <label for="indicatorCol">Indicator Column (optional):</label>
-        <input
-          id="indicatorCol"
-          type="text"
-          maxlength="2"
-          value={$auditConfig.columns.indicator || ''}
-          onchange={(e) => updateColumn('indicator', (e.target as HTMLInputElement).value)}
-          placeholder="e.g., C"
-        />
-      </div>
-    </div>
-  {/if}
-
-  <!-- Validation Errors -->
-  {#if configErrors.length > 0}
-    <div class="errors">
-      {#each configErrors as error (error)}
-        <div class="error-message"><CircleX size={13} strokeWidth={2} /> {error}</div>
-      {/each}
-    </div>
-  {/if}
+  <label class="checkbox-row">
+    <input type="checkbox" bind:checked={$auditIgnoreTitle} />
+    <span>Ignore title mismatches</span>
+  </label>
 </div>
 
 <style>
@@ -342,15 +54,21 @@
     gap: 0.75rem;
   }
 
-  .presets {
-    margin-bottom: 0;
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
   }
 
-  .presets label {
-    display: block;
-    margin-bottom: 8px;
-    font-weight: 500;
-    color: var(--text);
+  .field-label {
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--text-muted);
+  }
+
+  .field small {
+    font-size: 0.74rem;
+    color: var(--text-muted);
   }
 
   .preset-buttons {
@@ -361,17 +79,19 @@
 
   .preset-btn {
     padding: 6px 12px;
-    border: 2px solid var(--border);
+    border: 1px solid var(--border);
     background: var(--surface-elevated);
     border-radius: var(--radius);
     cursor: pointer;
-    transition: all 0.2s;
-    font-size: 0.9em;
+    transition: all 0.15s ease;
+    font-family: var(--font-family);
+    font-size: 0.85rem;
     color: var(--text);
   }
 
   .preset-btn:hover {
-    border-color: var(--accent);
+    border-color: var(--brand);
+    color: var(--brand);
   }
 
   .preset-btn.active {
@@ -380,220 +100,58 @@
     border-color: var(--accent);
   }
 
-  .settings-group {
+  .preset-btn:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(var(--brand-rgb), 0.18);
+  }
+
+  .binding-summary {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 15px;
-    margin-bottom: 20px;
+    grid-template-columns: 1fr 1fr;
+    gap: 6px 14px;
+    margin: 0;
+    padding: 10px 12px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--surface-elevated);
   }
 
-  .input-group {
+  .binding-summary div {
     display: flex;
-    flex-direction: column;
-    gap: 5px;
+    justify-content: space-between;
+    gap: 8px;
+    font-size: 0.76rem;
   }
 
-  .input-group label {
-    font-weight: 500;
-    color: var(--text);
-    font-size: 0.95em;
-  }
-
-  .input-group input {
-    padding: 8px;
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    font-size: 1em;
-    background: var(--surface-elevated);
-    color: var(--text);
-  }
-
-  .input-group input:focus {
-    outline: none;
-    border-color: var(--brand);
-    box-shadow: 0 0 0 3px rgba(var(--brand-rgb), 0.18);
-  }
-
-  .input-group select {
-    padding: 8px;
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    font-size: 1em;
-    background: var(--surface-elevated);
-    color: var(--text);
-    cursor: pointer;
-  }
-
-  .input-group select:focus {
-    outline: none;
-    border-color: var(--brand);
-    box-shadow: 0 0 0 3px rgba(var(--brand-rgb), 0.18);
-  }
-
-  .input-group small {
-    font-size: 0.8em;
+  .binding-summary dt {
     color: var(--text-muted);
   }
 
-  .checkbox-group {
-    flex-direction: row;
-    align-items: center;
-    gap: 10px;
+  .binding-summary dd {
+    margin: 0;
+    color: var(--text);
+    font-weight: 600;
   }
 
-  .checkbox-group label {
+  .checkbox-row {
     display: flex;
     align-items: center;
     gap: 8px;
-    margin-bottom: 0;
-    font-weight: 500;
-    cursor: pointer;
+    font-size: 0.82rem;
     color: var(--text);
+    cursor: pointer;
   }
 
-  .checkbox-group input[type='checkbox'] {
-    width: 18px;
-    height: 18px;
+  .checkbox-row input[type='checkbox'] {
+    width: 16px;
+    height: 16px;
     cursor: pointer;
-    margin: 0;
-    padding: 0;
     accent-color: var(--accent);
-  }
-
-  .checkbox-group span {
-    color: var(--text);
-    font-size: 0.95em;
-  }
-
-  .checkbox-group small {
-    flex: 1;
-    margin-left: 26px;
-    color: var(--text-muted);
-  }
-
-  .toggle-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-    background: none;
-    border: none;
-    color: var(--text);
-    font-family: var(--font-family);
-    font-weight: 600;
-    cursor: pointer;
-    padding: 0;
-    font-size: 0.85rem;
-    margin: 6px 0;
-  }
-
-  .toggle-btn:hover { color: var(--brand); }
-  .toggle-btn:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(var(--brand-rgb), 0.18); border-radius: var(--radius); }
-  .chev { display: inline-flex; color: var(--text-muted); transition: transform 150ms ease; }
-  .chev.open { transform: rotate(90deg); }
-
-  .error-message {
-    display: flex;
-    align-items: center;
-    gap: 0.35rem;
-    color: var(--danger);
-    font-size: 0.85em;
-    margin: 5px 0;
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .chev { transition: none; }
-  }
-
-  .advanced-settings {
-    background: var(--surface-elevated);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    padding: 15px;
-    margin-top: 10px;
-  }
-
-  .help-text {
-    font-size: 0.9em;
-    color: var(--text-muted);
-    margin-top: 0;
-    margin-bottom: 15px;
-    font-style: italic;
-  }
-
-  .answer-columns {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
-    gap: 8px;
-  }
-
-  .answer-columns input {
-    padding: 6px;
-    font-size: 0.9em;
-  }
-
-  .errors {
-    margin-top: 15px;
-    padding: 10px;
-    background: rgba(220, 38, 38, 0.1);
-    border: 1px solid var(--danger);
-    border-radius: var(--radius);
-  }
-
-  :global(.dark) .presets label,
-  :global(.dark) .input-group label {
-    color: var(--text);
-  }
-
-  :global(.dark) .preset-btn {
-    background: var(--surface-elevated);
-    border-color: var(--border);
-    color: var(--text);
-  }
-
-  :global(.dark) .preset-btn:hover {
-    border-color: var(--accent);
-  }
-
-  :global(.dark) .preset-btn.active {
-    background: var(--accent);
-    border-color: var(--accent);
-    color: var(--accent-foreground);
-  }
-
-  :global(.dark) .input-group input {
-    background: var(--surface-elevated);
-    border-color: var(--border);
-    color: var(--text);
-  }
-
-  :global(.dark) .input-group select {
-    background: var(--surface-elevated);
-    border-color: var(--border);
-    color: var(--text);
-  }
-
-  :global(.dark) .toggle-btn {
-    color: var(--accent);
-  }
-
-  :global(.dark) .advanced-settings {
-    background: var(--surface-elevated);
-    border-color: var(--border);
-  }
-
-  :global(.dark) .checkbox-group label {
-    color: var(--text);
-  }
-
-  :global(.dark) .checkbox-group span {
-    color: var(--text);
-  }
-
-  :global(.dark) .checkbox-group input[type='checkbox'] {
-    accent-color: var(--accent);
-  }
-
-  :global(.dark) .help-text {
-    color: var(--text-muted);
+    .preset-btn {
+      transition: none;
+    }
   }
 </style>

--- a/mono/src/lib/audit/AuditResults.svelte
+++ b/mono/src/lib/audit/AuditResults.svelte
@@ -35,9 +35,9 @@
   const stats = $derived(calculateStatistics(report));
 
   const status = $derived(
-    report.summary.bloquants > 0
+    report.summary.bloquants > 0 || report.summary.unmatched > 0
       ? "fail"
-      : report.summary.majeurs > 0 || report.summary.unmatched > 0
+      : report.summary.majeurs > 0
         ? "warning"
         : "pass",
   );
@@ -72,9 +72,9 @@
       {:else}<CircleCheck size={18} strokeWidth={1.9} />{/if}
     </span>
     <span class="banner-text">
-      {#if report.summary.bloquants > 0}Critical issues found
+      {#if report.summary.unmatched > 0}{report.summary.unmatched} unmatched question(s) — count/order mismatch
+      {:else if report.summary.bloquants > 0}Critical issues found
       {:else if report.summary.majeurs > 0}Major issues found
-      {:else if report.summary.unmatched > 0}Unmatched items found
       {:else}All checks passed{/if}
     </span>
     <span class="banner-time">{new Date(report.timestamp).toLocaleString()}</span>

--- a/mono/src/lib/audit/ErrorDetails.svelte
+++ b/mono/src/lib/audit/ErrorDetails.svelte
@@ -157,7 +157,7 @@
               <div class="answer-text">
                 {#if i < pair.excel.answers.length}
                   <HighlightedText
-                    text={pair.excel.answers[i]}
+                    text={pair.excel.answers[i].text}
                     diffs={answerError?.detail?.excelDiff}
                   />
                 {:else}

--- a/mono/src/lib/audit/__tests__/audit.test.ts
+++ b/mono/src/lib/audit/__tests__/audit.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'bun:test';
+import { matchPositional } from '../matcher';
+import { compare } from '../comparator';
+import { buildReport } from '../classifier';
+import type { QTIQuestion } from '../types';
+
+function q(
+	prompt: string,
+	answers: Array<[string, boolean]>,
+	extra: Partial<QTIQuestion> = {}
+): QTIQuestion {
+	return {
+		id: extra.id ?? prompt,
+		title: extra.title,
+		prompt,
+		answers: answers.map(([text, correct], i) => ({ text, correct, id: `a${i}` })),
+		type: extra.type ?? 'QCM',
+		metadata: extra.metadata ?? {}
+	};
+}
+
+describe('matchPositional', () => {
+	it('pairs questions by index when counts are equal', () => {
+		const excel = [q('Q1', [['a', true], ['b', false]]), q('Q2', [['c', true], ['d', false]])];
+		const qti = [q('Q1', [['a', true], ['b', false]]), q('Q2', [['c', true], ['d', false]])];
+
+		const { pairs, unmatchedExcel, unmatchedQTI } = matchPositional(excel, qti);
+
+		expect(pairs).toHaveLength(2);
+		expect(pairs[0].excel).toBe(excel[0]);
+		expect(pairs[0].qti).toBe(qti[0]);
+		expect(unmatchedExcel).toHaveLength(0);
+		expect(unmatchedQTI).toHaveLength(0);
+	});
+
+	it('reports leftovers when the Excel side is longer', () => {
+		const excel = [q('Q1', [['a', true]]), q('Q2', [['b', true]]), q('Q3', [['c', true]])];
+		const qti = [q('Q1', [['a', true]]), q('Q2', [['b', true]])];
+
+		const { pairs, unmatchedExcel, unmatchedQTI } = matchPositional(excel, qti);
+
+		expect(pairs).toHaveLength(2);
+		expect(unmatchedExcel).toHaveLength(1);
+		expect(unmatchedExcel[0].question).toBe(excel[2]);
+		expect(unmatchedQTI).toHaveLength(0);
+	});
+});
+
+describe('compare (QTIQuestion vs QTIQuestion)', () => {
+	it('flags answer count mismatch as BLOQUANT', () => {
+		const pair = {
+			excel: q('Q', [['a', true], ['b', false]]),
+			qti: q('Q', [['a', true], ['b', false], ['c', false]]),
+			score: 1
+		};
+		const errors = compare(pair);
+		const countErr = errors.find((e) => e.type === 'answer_count_mismatch');
+		expect(countErr?.severity).toBe('BLOQUANT');
+	});
+
+	it('flags correct-answer position mismatch as MAJEUR', () => {
+		const pair = {
+			excel: q('Q', [['a', true], ['b', false]]),
+			qti: q('Q', [['a', false], ['b', true]]),
+			score: 1
+		};
+		const errors = compare(pair);
+		const posErr = errors.find((e) => e.type === 'correct_answer_position_mismatch');
+		expect(posErr?.severity).toBe('MAJEUR');
+	});
+
+	it('reports no errors for identical questions', () => {
+		const pair = {
+			excel: q('Same prompt', [['a', true], ['b', false]]),
+			qti: q('Same prompt', [['a', true], ['b', false]]),
+			score: 1
+		};
+		expect(compare(pair, { ignoreTitleMismatch: true })).toHaveLength(0);
+	});
+});
+
+describe('buildReport', () => {
+	it('folds unmatched questions into the critical (bloquant) count', () => {
+		const pair = {
+			excel: q('Q1', [['a', true], ['b', false]]),
+			qti: q('Q1', [['a', true], ['b', false]]),
+			score: 1
+		};
+		const report = buildReport(
+			[pair],
+			[{ pair, errors: [] }],
+			[{ question: q('Lonely excel', [['x', true]]), closeMatches: [] }],
+			[]
+		);
+
+		expect(report.summary.unmatched).toBe(1);
+		expect(report.summary.bloquants).toBeGreaterThanOrEqual(1);
+	});
+});

--- a/mono/src/lib/audit/classifier.ts
+++ b/mono/src/lib/audit/classifier.ts
@@ -53,12 +53,17 @@ export function buildReport(
   });
   const duplicateTitles = Object.values(titleCounts).filter((count) => count > 1).length;
 
+  // An unmatched question (on either side) is a critical failure: these are
+  // compliance-critical comparisons, so "no match" must never read as OK. Fold
+  // the unmatched count into the BLOQUANT total so the audit fails.
+  const unmatchedCount = unmatchedExcel.length + unmatchedQTI.length;
+
   return {
     summary: {
       total: pairs.length,
       matched: pairs.length,
-      unmatched: unmatchedExcel.length + unmatchedQTI.length,
-      bloquants: errorCounts.BLOQUANT,
+      unmatched: unmatchedCount,
+      bloquants: errorCounts.BLOQUANT + unmatchedCount,
       majeurs: errorCounts.MAJEUR,
       mineurs: errorCounts.MINEUR,
       duplicateTitles,
@@ -192,11 +197,15 @@ export function createQuickSummary(report: AuditReport): {
 } {
   const bloquants = report.summary.bloquants;
   const majeurs = report.summary.majeurs;
+  const unmatched = report.summary.unmatched;
 
   let status: 'PASS' | 'WARNING' | 'FAIL' = 'PASS';
   let recommendation = 'All checks passed. Data is consistent.';
 
-  if (bloquants > 0) {
+  if (unmatched > 0) {
+    status = 'FAIL';
+    recommendation = `${unmatched} question(s) could not be matched (count/order mismatch between Excel and QTI). These are treated as critical and must be resolved.`;
+  } else if (bloquants > 0) {
     status = 'FAIL';
     recommendation = `${bloquants} critical issue(s) found. Must be resolved before deployment.`;
   } else if (majeurs > 0) {

--- a/mono/src/lib/audit/comparator.ts
+++ b/mono/src/lib/audit/comparator.ts
@@ -84,13 +84,13 @@ export function compare(
   }
 
   // Check question type mismatch
-  if (pair.qti.type && pair.excel.metadata.type && pair.qti.type !== pair.excel.metadata.type) {
+  if (pair.qti.type && pair.excel.type && pair.qti.type !== pair.excel.type) {
     errors.push({
       type: 'type_mismatch',
       severity: 'MAJEUR',
       detail: {
         field: 'type',
-        excel: pair.excel.metadata.type,
+        excel: pair.excel.type,
         qti: pair.qti.type,
       },
     });
@@ -123,7 +123,7 @@ function compareAnswers(pair: MatchedPair, options: NormalizationOptions): Compa
   // Compare answer texts (position by position)
   const minLen = Math.min(excelAnswers.length, qtiAnswers.length);
   for (let i = 0; i < minLen; i++) {
-    const excelText = normalize(excelAnswers[i], options);
+    const excelText = normalize(excelAnswers[i].text, options);
     const qtiText = normalize(qtiAnswers[i].text, options);
 
     if (excelText !== qtiText) {
@@ -143,8 +143,7 @@ function compareAnswers(pair: MatchedPair, options: NormalizationOptions): Compa
   }
 
   // Check if correct answer position matches
-  // Excel's correctAnswerIndex points to the correct answer position
-  const excelCorrectPos = pair.excel.correctAnswerIndex;
+  const excelCorrectPos = excelAnswers.findIndex((a) => a.correct);
   const qtiCorrectPos = qtiAnswers.findIndex((a) => a.correct);
 
   if (excelCorrectPos !== qtiCorrectPos) {
@@ -179,40 +178,6 @@ function compareAnswers(pair: MatchedPair, options: NormalizationOptions): Compa
         qti: correctCount,
       },
     });
-  }
-
-  return errors;
-}
-
-/**
- * Compare sequences of matched pairs to detect order mismatches
- * Returns errors for each pair that has incorrect order
- */
-export function compareSequence(
-  pairs: MatchedPair[],
-  excelOrder: number[],
-  qtiOrder: number[]
-): ComparisonError[] {
-  const errors: ComparisonError[] = [];
-
-  // Check if order is preserved or randomized
-  for (let i = 0; i < pairs.length; i++) {
-    const pair = pairs[i];
-    const expectedIndex = excelOrder.indexOf(pair.excel.rowIndex);
-    const actualIndex = qtiOrder.indexOf(i);
-
-    if (expectedIndex !== actualIndex) {
-      errors.push({
-        type: 'question_order_mismatch',
-        severity: 'MAJEUR',
-        detail: {
-          field: 'order',
-          index: i,
-          excel: expectedIndex,
-          qti: actualIndex,
-        },
-      });
-    }
   }
 
   return errors;

--- a/mono/src/lib/audit/config.ts
+++ b/mono/src/lib/audit/config.ts
@@ -1,3 +1,7 @@
+// NOTE: The /audit route no longer uses this config — it parses Excel via the
+// Import pipeline (`fromExcel.ts` + `bindingTemplate`). These `ExcelConfig`
+// presets remain in use by library ingest (`lib/library/parse/ingestFromExcel.ts`)
+// and the Excel adapter (`lib/questions/adapters/excel.ts`).
 import type { ExcelConfig } from './types';
 
 export const DEFAULT_CONFIG: ExcelConfig = {

--- a/mono/src/lib/audit/fromExcel.ts
+++ b/mono/src/lib/audit/fromExcel.ts
@@ -1,0 +1,77 @@
+import * as XLSX from 'xlsx';
+import type { AssessmentItem } from '$lib/questions/types.js';
+import { Question } from '$lib/import/helper/question';
+import { qcmsToAssessmentItems } from '$lib/import/helper/toQuestionType';
+import { bindingTemplate, type TemplateColumn } from '$lib/import/helper/store';
+
+/**
+ * Column/row binding accepted by the import parser `Question.parseSheet`.
+ * Mirrors the shape used by the Import route (`lib/import/helper/store.ts`
+ * `bindingTemplate`) so the audit parses Excel with the exact same pipeline.
+ */
+export interface ExcelBinding {
+	column: {
+		title: string;
+		prompt: string;
+		correct: string;
+		competency: string;
+		indicator: string;
+		competencyDescr: string;
+		masteryDescr: string;
+	};
+	row: { offset: number; alternative: number; skipRow: number };
+}
+
+/**
+ * Resolve a full {@link ExcelBinding} (all fields as strings) from one of the
+ * Import route's templates (`bindingTemplate`). The same templates power the
+ * Import sidebar, so the audit and import stay in lock-step.
+ */
+export function bindingFromTemplate(template: TemplateColumn): ExcelBinding {
+	const b = bindingTemplate[template];
+	return {
+		column: {
+			title: b.column.title ?? '',
+			prompt: b.column.prompt ?? '',
+			correct: b.column.correct ?? '',
+			competency: b.column.competency ?? '',
+			indicator: b.column.indicator ?? '',
+			competencyDescr: b.column.competencyDescr ?? '',
+			masteryDescr: b.column.masteryDescr ?? ''
+		},
+		row: { ...b.row }
+	};
+}
+
+/** Matches leading example/instruction questions ("Voorbeeld" / "Exemple"). */
+const EXAMPLE_RE = /^\s*(voorbeeld|exemple)/i;
+
+/**
+ * Parse an uploaded Excel workbook into normalized {@link AssessmentItem}s using
+ * the **same** functions as the Import route (`Question.parseSheet` +
+ * `qcmsToAssessmentItems`). This is the single point of reuse — no parsing logic
+ * is duplicated from the import flow.
+ *
+ * Leading example rows ("Voorbeeld"/"Exemple") are dropped so the question
+ * sequence lines up positionally with the TAO QTI export (which filters
+ * instruction items on its side).
+ */
+export function parseExcelToAssessmentItems(
+	buffer: ArrayBuffer,
+	binding: ExcelBinding,
+	sheetName?: string
+): AssessmentItem[] {
+	const wb = XLSX.read(buffer);
+	const selectedSheet = sheetName && wb.SheetNames.includes(sheetName) ? sheetName : wb.SheetNames[0];
+	if (!selectedSheet) throw new Error('No sheets found in Excel file');
+
+	const sheet = wb.Sheets[selectedSheet];
+	const qcms = Question.parseSheet(sheet, binding.column, binding.row);
+	const items = qcmsToAssessmentItems(qcms);
+
+	return items.filter((item) => {
+		const title = item.title ?? '';
+		const prompt = item.content.text ?? item.content.html ?? '';
+		return !EXAMPLE_RE.test(title) && !EXAMPLE_RE.test(prompt);
+	});
+}

--- a/mono/src/lib/audit/index.ts
+++ b/mono/src/lib/audit/index.ts
@@ -1,22 +1,29 @@
-import type { ExcelConfig, AuditReport, ExcelQuestion, QTIQuestion } from './types';
-import { parseExcel } from './excel-parser';
-import { matchQuestions } from './matcher';
+import type { AuditReport, QTIQuestion } from './types';
+import { parseExcelToAssessmentItems, type ExcelBinding } from './fromExcel';
+import { assessmentItemsToQuestions } from './fromAssessment';
+import { matchPositional } from './matcher';
 import { compare } from './comparator';
 import { buildReport } from './classifier';
 import type { NormalizationOptions } from './types';
 
 /**
- * Main audit orchestrator
- * Runs the complete pipeline: parse → match → compare → classify → report
+ * Main audit orchestrator.
+ * Runs the complete pipeline: parse → match → compare → classify → report.
+ *
+ * Both sides are parsed with the canonical app parsers: the Excel side via the
+ * Import pipeline (`parseExcelToAssessmentItems`) and the QTI side via QtiAdapter
+ * (already converted to `qtiQuestions` by the caller). Matching is positional —
+ * the TAO export is generated from the Excel, so the two lists share order and
+ * count, and any drift surfaces as critical unmatched items.
  */
 export async function runAudit(
   excelBuffer: ArrayBuffer,
   qtiQuestions: QTIQuestion[],
-  config: ExcelConfig,
+  binding: ExcelBinding,
   options?: {
-    threshold?: number;
     normOptions?: Partial<NormalizationOptions>;
     sheetName?: string;
+    ignoreTitleMismatch?: boolean;
   }
 ): Promise<{
   success: boolean;
@@ -27,12 +34,16 @@ export async function runAudit(
   const warnings: string[] = [];
 
   try {
-    // Step 1: Parse Excel
-    console.log('[Audit] Step 1: Parsing Excel file...');
-    let excelQuestions: ExcelQuestion[];
+    // Step 1: Parse Excel with the Import pipeline, then normalize to QTIQuestion.
+    console.log('[Audit] Step 1: Parsing Excel file (Import pipeline)...');
+    let excelQuestions: QTIQuestion[];
 
     try {
-      excelQuestions = await parseExcel(excelBuffer, config, options?.sheetName);
+      const excelItems = parseExcelToAssessmentItems(excelBuffer, binding, options?.sheetName);
+      excelQuestions = assessmentItemsToQuestions(excelItems).map((q, i) => ({
+        ...q,
+        metadata: { ...q.metadata, excelRow: i + 1 },
+      }));
     } catch (error) {
       return {
         success: false,
@@ -47,56 +58,40 @@ export async function runAudit(
       };
     }
 
-    console.log(`[Audit] Found ${excelQuestions.length} questions in Excel`);
-    
-    // Debug: Log first question details
-    if (excelQuestions.length > 0) {
-      const first = excelQuestions[0];
-      console.log('[Audit] First Excel question:', {
-        rowIndex: first.rowIndex,
-        excelRow: first.metadata.excelRow,
-        title: first.title?.substring(0, 50),
-        prompt: first.prompt.substring(0, 80),
-        answers: first.answers.length,
-        correctAnswerIndex: first.correctAnswerIndex,
-      });
-    }
+    console.log(`[Audit] Found ${excelQuestions.length} Excel questions, ${qtiQuestions.length} QTI questions`);
 
-    // Step 2: Match questions
-    console.log('[Audit] Step 2: Matching Excel questions to QTI...');
-    const threshold = options?.threshold ?? 0.85;
-    const { pairs, unmatchedExcel, unmatchedQTI } = matchQuestions(
+    // Step 2: Positional matching (order-based).
+    console.log('[Audit] Step 2: Matching Excel questions to QTI (positional)...');
+    const { pairs, unmatchedExcel, unmatchedQTI } = matchPositional(
       excelQuestions,
       qtiQuestions,
-      threshold,
       options?.normOptions,
-      { ignoreTitleMismatch: config.ignoreTitleMismatch }
+      { ignoreTitleMismatch: options?.ignoreTitleMismatch }
     );
 
-    console.log(`[Audit] Matched ${pairs.length} pairs`);
-    if (unmatchedExcel.length > 0) {
-      warnings.push(`${unmatchedExcel.length} Excel questions had no match (similarity < ${threshold})`);
-    }
-    if (unmatchedQTI.length > 0) {
-      warnings.push(`${unmatchedQTI.length} QTI questions were not matched to Excel`);
+    if (excelQuestions.length !== qtiQuestions.length) {
+      warnings.push(
+        `Question count mismatch — Excel: ${excelQuestions.length}, QTI: ${qtiQuestions.length}. ${unmatchedExcel.length + unmatchedQTI.length} question(s) could not be paired.`
+      );
     }
 
-    // Step 3: Compare each pair
+    // Step 3: Compare each matched pair.
     console.log('[Audit] Step 3: Comparing matched pairs...');
     const results = pairs.map((pair) => ({
       pair,
       errors: compare(pair, {
         ...options?.normOptions,
-        ignoreTitleMismatch: config.ignoreTitleMismatch,
+        ignoreTitleMismatch: options?.ignoreTitleMismatch,
       }),
     }));
 
-    // Step 4: Build report
+    // Step 4: Build report (unmatched items are folded into the critical count).
     console.log('[Audit] Step 4: Building report...');
     const report = buildReport(pairs, results, unmatchedExcel, unmatchedQTI);
 
     console.log('[Audit] Audit complete:', {
       matched: report.summary.matched,
+      unmatched: report.summary.unmatched,
       bloquants: report.summary.bloquants,
       majeurs: report.summary.majeurs,
       mineurs: report.summary.mineurs,

--- a/mono/src/lib/audit/matcher.ts
+++ b/mono/src/lib/audit/matcher.ts
@@ -1,30 +1,95 @@
-import { normalize, jaroWinkler, generateDiff } from './normalize';
-import type { ExcelQuestion, QTIQuestion, MatchedPair, NormalizationOptions, CloseMatch, UnmatchedItem, ScoringDetails } from './types';
+import { normalize, jaroWinkler } from './normalize';
+import type {
+  QTIQuestion,
+  QTIAnswer,
+  MatchedPair,
+  NormalizationOptions,
+  CloseMatch,
+  UnmatchedItem,
+  ScoringDetails,
+} from './types';
 
-interface MatchScore {
-  excelIdx: number;
-  qtiIdx: number;
-  score: number;
-  details: {
-    titleScore: number;
-    promptScore: number;
-    answerScore: number;
-  };
+/**
+ * Positional (order-based) matching.
+ *
+ * The TAO QTI export is generated from the Excel source via the Import route, so
+ * the two question lists share the same order and count. We therefore pair them
+ * by index (question #i ↔ question #i) instead of fuzzy similarity. This is
+ * deterministic: every question pairs up, and any count/order drift surfaces as
+ * leftover unmatched items (treated as critical downstream).
+ *
+ * The per-pair similarity score is still computed, but only as a confidence/
+ * diagnostic value for display — it never gates the match.
+ *
+ * @param excelQs - Excel-derived questions (from the Import pipeline)
+ * @param qtiQs - QTI questions (from QtiAdapter)
+ * @param normOptions - Text normalization options
+ * @param options - Matching options (ignoreTitleMismatch)
+ */
+export function matchPositional(
+  excelQs: QTIQuestion[],
+  qtiQs: QTIQuestion[],
+  normOptions?: Partial<NormalizationOptions>,
+  options?: { ignoreTitleMismatch?: boolean }
+): {
+  pairs: MatchedPair[];
+  unmatchedExcel: UnmatchedItem[];
+  unmatchedQTI: UnmatchedItem[];
+} {
+  const pairs: MatchedPair[] = [];
+  const n = Math.min(excelQs.length, qtiQs.length);
+
+  for (let i = 0; i < n; i++) {
+    const similarity = calculateSimilarity(excelQs[i], qtiQs[i], normOptions, options?.ignoreTitleMismatch);
+    pairs.push({ excel: excelQs[i], qti: qtiQs[i], score: similarity.total });
+  }
+
+  // Anything past the shorter list has no positional counterpart.
+  const unmatchedExcel: UnmatchedItem[] = excelQs.slice(n).map((excelQ) => ({
+    question: excelQ,
+    closeMatches: buildCloseMatches(excelQ, qtiQs, normOptions, options?.ignoreTitleMismatch),
+  }));
+
+  const unmatchedQTI: UnmatchedItem[] = qtiQs.slice(n).map((qtiQ) => ({
+    question: qtiQ,
+    closeMatches: buildCloseMatches(qtiQ, excelQs, normOptions, options?.ignoreTitleMismatch),
+  }));
+
+  return { pairs, unmatchedExcel, unmatchedQTI };
+}
+
+/** Top-3 most similar candidates, annotated with copy-paste heuristics. */
+function buildCloseMatches(
+  target: QTIQuestion,
+  candidates: QTIQuestion[],
+  normOptions?: Partial<NormalizationOptions>,
+  ignoreTitleMismatch?: boolean
+): CloseMatch[] {
+  return candidates
+    .map((candidate) => {
+      const similarity = calculateSimilarity(target, candidate, normOptions, ignoreTitleMismatch);
+      return { candidate, ...similarity };
+    })
+    .sort((a, b) => b.total - a.total)
+    .slice(0, 3)
+    .map((match) => {
+      const isCopyPaste = detectCopyPasteError(match.details);
+      return {
+        question: match.candidate,
+        score: match.total,
+        scoring: match.details,
+        isCopyPasteError: isCopyPaste.detected,
+        copyPasteReason: isCopyPaste.reason,
+      } as CloseMatch;
+    });
 }
 
 /**
- * Match Excel questions to QTI questions using similarity scoring
- * Ensures 1:1 bidirectional mapping (each Excel matches max one QTI and vice versa)
- *
- * @param excelQs - Questions parsed from Excel
- * @param qtiQs - Questions from QTI
- * @param threshold - Similarity threshold (0-1, default 0.85)
- * @param normOptions - Text normalization options
- * @param options - Matching options (ignoreTitleMismatch)
- * @returns Matched pairs and unmatched items with close matches
+ * Fuzzy similarity matching (greedy 1:1 above a threshold). Retained for
+ * diagnostics/fallback; the primary audit path uses {@link matchPositional}.
  */
 export function matchQuestions(
-  excelQs: ExcelQuestion[],
+  excelQs: QTIQuestion[],
   qtiQs: QTIQuestion[],
   threshold: number = 0.85,
   normOptions?: Partial<NormalizationOptions>,
@@ -38,155 +103,54 @@ export function matchQuestions(
   const matchedQTIIndices = new Set<number>();
   const matchedExcelIndices = new Set<number>();
 
-  // Calculate all similarity scores
-  const scores: MatchScore[] = [];
-
+  const scores: Array<{ excelIdx: number; qtiIdx: number; score: number }> = [];
   for (let ei = 0; ei < excelQs.length; ei++) {
     for (let qi = 0; qi < qtiQs.length; qi++) {
       const similarity = calculateSimilarity(excelQs[ei], qtiQs[qi], normOptions, options?.ignoreTitleMismatch);
-
-      scores.push({
-        excelIdx: ei,
-        qtiIdx: qi,
-        score: similarity.total,
-        details: similarity.details,
-      });
+      scores.push({ excelIdx: ei, qtiIdx: qi, score: similarity.total });
     }
   }
 
-  // Sort by score descending to process best matches first
   scores.sort((a, b) => b.score - a.score);
 
-  // Greedy matching: assign best scores that haven't been matched yet
-  for (const scoreEntry of scores) {
-    if (scoreEntry.score >= threshold) {
-      // Only match if both questions haven't been matched yet
-      if (!matchedExcelIndices.has(scoreEntry.excelIdx) && !matchedQTIIndices.has(scoreEntry.qtiIdx)) {
-        pairs.push({
-          excel: excelQs[scoreEntry.excelIdx],
-          qti: qtiQs[scoreEntry.qtiIdx],
-          score: scoreEntry.score,
-        });
-
-        matchedExcelIndices.add(scoreEntry.excelIdx);
-        matchedQTIIndices.add(scoreEntry.qtiIdx);
-      }
-    }
+  for (const entry of scores) {
+    if (entry.score < threshold) continue;
+    if (matchedExcelIndices.has(entry.excelIdx) || matchedQTIIndices.has(entry.qtiIdx)) continue;
+    pairs.push({ excel: excelQs[entry.excelIdx], qti: qtiQs[entry.qtiIdx], score: entry.score });
+    matchedExcelIndices.add(entry.excelIdx);
+    matchedQTIIndices.add(entry.qtiIdx);
   }
 
-  // Collect unmatched and find close matches
-  const unmatchedExcelIndices = excelQs
-    .map((_, i) => i)
-    .filter((i) => !matchedExcelIndices.has(i));
-  const unmatchedQTIIndices = qtiQs
-    .map((_, i) => i)
-    .filter((i) => !matchedQTIIndices.has(i));
+  const unmatchedExcel: UnmatchedItem[] = excelQs
+    .map((q, i) => ({ q, i }))
+    .filter(({ i }) => !matchedExcelIndices.has(i))
+    .map(({ q }) => ({ question: q, closeMatches: buildCloseMatches(q, qtiQs, normOptions, options?.ignoreTitleMismatch) }));
 
-  // Debug: Log first question matching scores
-  if (excelQs.length > 0) {
-    console.log('[Matcher] First Excel question matching scores:');
-    const firstExcel = excelQs[0];
-    const topScores = qtiQs.map((qtiQ, idx) => {
-      const sim = calculateSimilarity(firstExcel, qtiQ, normOptions, options?.ignoreTitleMismatch);
-      return { qtiIdx: idx, score: sim.total, details: sim.details };
-    }).sort((a, b) => b.score - a.score).slice(0, 3);
-    
-    topScores.forEach((s, i) => {
-      console.log(`  ${i + 1}. QTI question ${s.qtiIdx}: ${(s.score * 100).toFixed(1)}% (Prompt: ${(s.details.promptScore * 100).toFixed(0)}%, Answers: ${(s.details.answerScore * 100).toFixed(0)}%)`);
-    });
-  }
-
-  // Find close matches for unmatched Excel questions
-  const unmatchedExcel: UnmatchedItem[] = unmatchedExcelIndices.map((excelIdx) => {
-    const excelQ = excelQs[excelIdx];
-    
-    // Find all QTI scores for this Excel question to get top 3
-    const closeMatches = unmatchedQTIIndices
-      .map((qtiIdx) => {
-        const qtiQ = qtiQs[qtiIdx];
-        const similarity = calculateSimilarity(excelQ, qtiQ, normOptions, options?.ignoreTitleMismatch);
-        return {
-          qtiIdx,
-          qtiQ,
-          ...similarity,
-        };
-      })
-      .sort((a, b) => b.total - a.total)
-      .slice(0, 3)
-      .map((match) => {
-        const isCopyPaste = detectCopyPasteError(match.details);
-        return {
-          question: match.qtiQ,
-          score: match.total,
-          scoring: match.details,
-          isCopyPasteError: isCopyPaste.detected,
-          copyPasteReason: isCopyPaste.reason,
-        } as CloseMatch;
-      });
-
-    return {
-      question: excelQ,
-      closeMatches,
-    } as UnmatchedItem;
-  });
-
-  // Find close matches for unmatched QTI questions
-  const unmatchedQTI: UnmatchedItem[] = unmatchedQTIIndices.map((qtiIdx) => {
-    const qtiQ = qtiQs[qtiIdx];
-    
-    const closeMatches = unmatchedExcelIndices
-      .map((excelIdx) => {
-        const excelQ = excelQs[excelIdx];
-        const similarity = calculateSimilarity(excelQ, qtiQ, normOptions, options?.ignoreTitleMismatch);
-        return {
-          excelIdx,
-          excelQ,
-          ...similarity,
-        };
-      })
-      .sort((a, b) => b.total - a.total)
-      .slice(0, 3)
-      .map((match) => {
-        const isCopyPaste = detectCopyPasteError(match.details);
-        return {
-          question: match.excelQ,
-          score: match.total,
-          scoring: match.details,
-          isCopyPasteError: isCopyPaste.detected,
-          copyPasteReason: isCopyPaste.reason,
-        } as CloseMatch;
-      });
-
-    return {
-      question: qtiQ,
-      closeMatches,
-    } as UnmatchedItem;
-  });
+  const unmatchedQTI: UnmatchedItem[] = qtiQs
+    .map((q, i) => ({ q, i }))
+    .filter(({ i }) => !matchedQTIIndices.has(i))
+    .map(({ q }) => ({ question: q, closeMatches: buildCloseMatches(q, excelQs, normOptions, options?.ignoreTitleMismatch) }));
 
   return { pairs, unmatchedExcel, unmatchedQTI };
 }
 
 /**
- * Calculate similarity between Excel and QTI question
- * Returns weighted score and component scores
- * NEW WEIGHTING: Title is ignored (0%), Prompt 60%, Answers 40%
+ * Calculate similarity between two questions.
+ * Title is ignored for scoring (0%); Prompt 60%, Answers 40%.
  */
 function calculateSimilarity(
-  excelQ: ExcelQuestion,
-  qtiQ: QTIQuestion,
+  a: QTIQuestion,
+  b: QTIQuestion,
   normOptions?: Partial<NormalizationOptions>,
-  ignoreTitleMismatch?: boolean
+  _ignoreTitleMismatch?: boolean
 ): {
   total: number;
   details: ScoringDetails;
 } {
-  // Calculate component scores
-  const titleScore = excelQ.title && qtiQ.title ? scoreField(excelQ.title, qtiQ.title, normOptions) : 1.0;
-  const promptScore = scoreField(excelQ.prompt, qtiQ.prompt, normOptions);
-  const answerScore = scoreAnswers(excelQ.answers, qtiQ.answers, normOptions);
+  const titleScore = a.title && b.title ? scoreField(a.title, b.title, normOptions) : 1.0;
+  const promptScore = scoreField(a.prompt, b.prompt, normOptions);
+  const answerScore = scoreAnswers(a.answers, b.answers, normOptions);
 
-  // NEW WEIGHTING: Title is no longer used for matching (0%)
-  // Prompt 60%, Answers 40%
   const total = promptScore * 0.6 + answerScore * 0.4;
 
   return {
@@ -195,9 +159,7 @@ function calculateSimilarity(
   };
 }
 
-/**
- * Score a single text field
- */
+/** Score a single text field. */
 function scoreField(
   text1: string,
   text2: string,
@@ -205,128 +167,48 @@ function scoreField(
 ): number {
   const n1 = normalize(text1, normOptions);
   const n2 = normalize(text2, normOptions);
-
   if (!n1 || !n2) return 0;
-
   return jaroWinkler(n1, n2);
 }
 
-/**
- * Score answer matching
- * Compares answer count and text similarity
- */
+/** Score answer matching: count plus per-position text similarity. */
 function scoreAnswers(
-  excelAnswers: string[],
-  qtiAnswers: any[],
+  answersA: QTIAnswer[],
+  answersB: QTIAnswer[],
   normOptions?: Partial<NormalizationOptions>
 ): number {
-  // Normalize QTI answers to text format
-  const qtiTexts = qtiAnswers.map((a) => (typeof a === 'string' ? a : a.text || ''));
+  const textsA = answersA.map((a) => a.text ?? '');
+  const textsB = answersB.map((a) => a.text ?? '');
 
-  // If answer count mismatch, reduce score significantly
-  if (excelAnswers.length !== qtiTexts.length) {
-    // Still give partial credit for similar answer sets
-    const minLen = Math.min(excelAnswers.length, qtiTexts.length);
+  if (textsA.length !== textsB.length) {
+    const minLen = Math.min(textsA.length, textsB.length);
     if (minLen === 0) return 0;
 
-    // Score only the overlapping answers
     let matchScore = 0;
     for (let i = 0; i < minLen; i++) {
-      matchScore += scoreField(excelAnswers[i], qtiTexts[i], normOptions);
+      matchScore += scoreField(textsA[i], textsB[i], normOptions);
     }
 
-    // Penalize count mismatch
-    const countDiff = Math.abs(excelAnswers.length - qtiTexts.length);
+    const countDiff = Math.abs(textsA.length - textsB.length);
     const countPenalty = Math.min(1, countDiff * 0.15);
-
     return (matchScore / minLen) * (1 - countPenalty);
   }
 
-  // Same number of answers - score each pair
+  if (textsA.length === 0) return 1;
+
   let totalScore = 0;
-  for (let i = 0; i < excelAnswers.length; i++) {
-    totalScore += scoreField(excelAnswers[i], qtiTexts[i], normOptions);
+  for (let i = 0; i < textsA.length; i++) {
+    totalScore += scoreField(textsA[i], textsB[i], normOptions);
   }
-
-  return totalScore / excelAnswers.length;
+  return totalScore / textsA.length;
 }
 
 /**
- * Find best match for a single Excel question
- * Useful for incremental matching or debugging
- */
-export function findBestMatch(
-  excelQ: ExcelQuestion,
-  qtiQs: QTIQuestion[],
-  normOptions?: Partial<NormalizationOptions>
-): {
-  best: QTIQuestion | null;
-  score: number;
-  topMatches: Array<{ question: QTIQuestion; score: number }>;
-} {
-  const scores = qtiQs.map((q) => ({
-    question: q,
-    score: calculateSimilarity(excelQ, q, normOptions).total,
-  }));
-
-  scores.sort((a, b) => b.score - a.score);
-
-  return {
-    best: scores[0]?.question || null,
-    score: scores[0]?.score || 0,
-    topMatches: scores.slice(0, 5),
-  };
-}
-
-/**
- * Batch matching with detailed match analysis
- */
-export function analyzeMismatches(
-  excelQs: ExcelQuestion[],
-  qtiQs: QTIQuestion[],
-  matchedPairs: MatchedPair[]
-): {
-  closeMatches: Array<{ excel: ExcelQuestion; best: QTIQuestion; score: number }>;
-  noMatch: ExcelQuestion[];
-  orphanedQTI: QTIQuestion[];
-} {
-  const matchedQTIIds = new Set(matchedPairs.map((p) => p.qti.id || p.qti.prompt));
-  const matchedExcelIds = new Set(matchedPairs.map((p) => p.excel.rowIndex));
-
-  const closeMatches: Array<{ excel: ExcelQuestion; best: QTIQuestion; score: number }> = [];
-  const noMatch: ExcelQuestion[] = [];
-
-  for (const excelQ of excelQs) {
-    if (matchedExcelIds.has(excelQ.rowIndex)) continue; // Already matched
-
-    const result = findBestMatch(excelQ, qtiQs);
-    if (result.best && result.score > 0.7) {
-      // Close but not matched
-      closeMatches.push({
-        excel: excelQ,
-        best: result.best,
-        score: result.score,
-      });
-    } else {
-      noMatch.push(excelQ);
-    }
-  }
-
-  const orphanedQTI = qtiQs.filter((q) => !matchedQTIIds.has(q.id || q.prompt));
-
-  return { closeMatches, noMatch, orphanedQTI };
-}
-
-/**
- * Detect potential copy-paste errors by analyzing score patterns
- * Copy-paste errors typically have:
- * - One strong component (e.g., prompt > 0.9)
- * - One weak component (e.g., title < 0.4)
+ * Detect potential copy-paste errors by analyzing score patterns.
  */
 function detectCopyPasteError(scoring: ScoringDetails): { detected: boolean; reason?: string } {
   const { promptScore, answerScore, titleScore } = scoring;
 
-  // Strong prompt, weak title → likely copied content with new title
   if (promptScore > 0.88 && titleScore < 0.4) {
     return {
       detected: true,
@@ -334,7 +216,6 @@ function detectCopyPasteError(scoring: ScoringDetails): { detected: boolean; rea
     };
   }
 
-  // Strong answers, weak prompt → questions might be reordered or re-explained
   if (answerScore > 0.88 && promptScore < 0.6) {
     return {
       detected: true,
@@ -342,7 +223,6 @@ function detectCopyPasteError(scoring: ScoringDetails): { detected: boolean; rea
     };
   }
 
-  // Strong answers and title, weak prompt → another reordering pattern
   if (answerScore > 0.88 && titleScore > 0.85 && promptScore < 0.5) {
     return {
       detected: true,
@@ -351,72 +231,4 @@ function detectCopyPasteError(scoring: ScoringDetails): { detected: boolean; rea
   }
 
   return { detected: false };
-}
-
-/**
- * Diagnostic tool: Analyze why a specific Excel question doesn't match
- * Returns detailed scoring breakdown for debugging
- */
-export function analyzeQuestionMatching(
-  excelQ: ExcelQuestion,
-  qtiQs: QTIQuestion[],
-  threshold: number = 0.85,
-  normOptions?: Partial<NormalizationOptions>
-): {
-  excelRowIndex: number;
-  excelTitle?: string;
-  excelPrompt: string;
-  topMatchesBelowThreshold: Array<{
-    qtiIndex: number;
-    qtiTitle?: string;
-    totalScore: number;
-    promptScore: number;
-    answerScore: number;
-    titleScore: number;
-    whyBelow: string;
-  }>;
-  topMatchesAboveThreshold?: Array<{
-    qtiIndex: number;
-    qtiTitle?: string;
-    totalScore: number;
-  }>;
-} {
-  const scores = qtiQs.map((qtiQ, idx) => {
-    const sim = calculateSimilarity(excelQ, qtiQ, normOptions);
-    return { idx, qtiQ, ...sim };
-  }).sort((a, b) => b.total - a.total);
-
-  const belowThreshold = scores.filter((s) => s.total < threshold).slice(0, 5);
-  const aboveThreshold = scores.filter((s) => s.total >= threshold).slice(0, 3);
-
-  return {
-    excelRowIndex: excelQ.rowIndex,
-    excelTitle: excelQ.title,
-    excelPrompt: excelQ.prompt.substring(0, 150),
-    topMatchesBelowThreshold: belowThreshold.map((s) => {
-      const gap = threshold - s.total;
-      let reason = '';
-      if (s.details.promptScore < 0.6) {
-        reason = `Prompt too low: ${(s.details.promptScore * 100).toFixed(0)}%`;
-      } else if (s.details.answerScore < 0.4) {
-        reason = `Answers too low: ${(s.details.answerScore * 100).toFixed(0)}%`;
-      } else {
-        reason = `Combined score ${(s.total * 100).toFixed(1)}% (gap: ${(gap * 100).toFixed(1)}%)`;
-      }
-      return {
-        qtiIndex: s.idx,
-        qtiTitle: s.qtiQ.title,
-        totalScore: s.total,
-        promptScore: s.details.promptScore,
-        answerScore: s.details.answerScore,
-        titleScore: s.details.titleScore,
-        whyBelow: reason,
-      };
-    }),
-    topMatchesAboveThreshold: aboveThreshold.map((s) => ({
-      qtiIndex: s.idx,
-      qtiTitle: s.qtiQ.title,
-      totalScore: s.total,
-    })),
-  };
 }

--- a/mono/src/lib/audit/report.ts
+++ b/mono/src/lib/audit/report.ts
@@ -539,7 +539,7 @@ export function buildCSV(report: AuditReport): string {
   for (const q of report.unmatched.qti) {
     const title = 'title' in q.question && q.question.title ? q.question.title : q.question.prompt;
     const id = 'id' in q.question ? q.question.id || '' : '';
-    rows.push(`Unmatched,INFO,"${title.substring(0, 50)}","${id}","No match found in Excel","","",`);
+    rows.push(`Unmatched,BLOQUANT,"${title.substring(0, 50)}","${id}","No match found in Excel","","",`);
   }
 
   return rows.join('\n');

--- a/mono/src/lib/audit/store.ts
+++ b/mono/src/lib/audit/store.ts
@@ -1,11 +1,12 @@
 import { writable } from 'svelte/store';
 import type { AssessmentItem } from '$lib/questions/types.js';
-import type { AuditReport, ExcelConfig } from './types';
-import { DEFAULT_CONFIG } from './config';
+import type { AuditReport } from './types';
+import { TemplateColumn } from '$lib/import/helper/store';
 
 /**
  * State for the standalone /audit route. The audit compares the QTI questions
- * parsed from a TAO ZIP (`auditItems`) against an uploaded Excel workbook.
+ * parsed from a TAO ZIP (`auditItems`) against an uploaded Excel workbook, which
+ * is parsed with the same Import-route templates (`auditTemplate`).
  */
 
 /** QTI questions parsed from the uploaded TAO export. */
@@ -15,7 +16,12 @@ export const auditZipName = writable<string>('');
 
 export const auditLoading = writable<boolean>(false);
 export const auditReport = writable<AuditReport | null>(null);
-export const auditConfig = writable<ExcelConfig>(DEFAULT_CONFIG);
+
+/** Import-route template used to parse the Excel source (FIN by default). */
+export const auditTemplate = writable<TemplateColumn>(TemplateColumn.FIN);
+/** Skip question-title mismatch checks (titles are real in Import output). */
+export const auditIgnoreTitle = writable<boolean>(false);
+
 /** Filename of the loaded Excel workbook. */
 export const auditFilename = writable<string>('');
 export const auditError = writable<string | null>(null);
@@ -26,7 +32,8 @@ export function resetAudit(): void {
 	auditReport.set(null);
 	auditFilename.set('');
 	auditError.set(null);
-	auditConfig.set(DEFAULT_CONFIG);
+	auditTemplate.set(TemplateColumn.FIN);
+	auditIgnoreTitle.set(false);
 }
 
 /** Clears everything, including the parsed QTI questions and ZIP name. */

--- a/mono/src/lib/audit/types.ts
+++ b/mono/src/lib/audit/types.ts
@@ -48,7 +48,10 @@ export interface QTIAnswer {
 }
 
 export interface MatchedPair {
-  excel: ExcelQuestion;
+  // Both sides are normalized to `QTIQuestion`: the QTI side via QtiAdapter and
+  // the Excel side via the Import pipeline (see `fromExcel.ts`). `excel` is the
+  // Excel-derived question.
+  excel: QTIQuestion;
   qti: QTIQuestion;
   score: number;
 }
@@ -64,6 +67,7 @@ export interface ComparisonError {
     | 'correct_answer_position_mismatch'
     | 'randomization_flag_mismatch'
     | 'question_order_mismatch'
+    | 'count_mismatch'
     | 'type_mismatch';
   severity: 'BLOQUANT' | 'MAJEUR' | 'MINEUR';
   detail?: {
@@ -134,7 +138,7 @@ export interface ScoringDetails {
  * Shows why it didn't match and helps detect copy-paste errors
  */
 export interface CloseMatch {
-  question: QTIQuestion | ExcelQuestion;
+  question: QTIQuestion;
   score: number;
   scoring: ScoringDetails;
   isCopyPasteError?: boolean;
@@ -145,7 +149,7 @@ export interface CloseMatch {
  * Enhanced unmatched item with close matches and quality indicators
  */
 export interface UnmatchedItem {
-  question: ExcelQuestion | QTIQuestion;
+  question: QTIQuestion;
   closeMatches: CloseMatch[];
   isDuplicate?: boolean;
   duplicateOf?: string | number;

--- a/mono/src/routes/audit/+page.svelte
+++ b/mono/src/routes/audit/+page.svelte
@@ -7,12 +7,14 @@
   import { runAudit } from "$lib/audit/index";
   import { getExcelSheets } from "$lib/audit/excel-parser";
   import { assessmentItemsToQuestions } from "$lib/audit/fromAssessment";
+  import { bindingFromTemplate } from "$lib/audit/fromExcel";
   import AuditConfig from "$lib/audit/AuditConfig.svelte";
   import AuditResults from "$lib/audit/AuditResults.svelte";
   import {
     auditItems,
     auditZipName,
-    auditConfig,
+    auditTemplate,
+    auditIgnoreTitle,
     auditFilename,
     auditReport,
     auditLoading,
@@ -23,7 +25,6 @@
   let excelFile = $state<File | null>(null);
   let sheets = $state<string[]>([]);
   let selectedSheet = $state("");
-  let threshold = $state(0.95);
 
   const ready = $derived($auditItems.length > 0 && excelFile !== null && selectedSheet !== "");
 
@@ -74,9 +75,9 @@
         return;
       }
       const buffer = await excelFile.arrayBuffer();
-      const result = await runAudit(buffer, questions, get(auditConfig), {
-        threshold,
+      const result = await runAudit(buffer, questions, bindingFromTemplate(get(auditTemplate)), {
         sheetName: selectedSheet,
+        ignoreTitleMismatch: get(auditIgnoreTitle),
       });
       if (result.success && result.report) auditReport.set(result.report);
       else auditError.set(result.error ?? "Unknown error during audit.");
@@ -92,7 +93,6 @@
     excelFile = null;
     sheets = [];
     selectedSheet = "";
-    threshold = 0.95;
   }
 
   function clearZip() {
@@ -144,12 +144,6 @@
 
     {#if $auditFilename}
       <AuditConfig />
-
-      <div class="field">
-        <label class="field-label" for="threshold">Match threshold — {(threshold * 100).toFixed(0)}%</label>
-        <input id="threshold" type="range" min="0.5" max="1" step="0.05" bind:value={threshold} />
-        <small>Higher = fewer but more confident matches.</small>
-      </div>
     {/if}
 
     <div class="actions">
@@ -191,7 +185,6 @@
 
   .field { display: flex; flex-direction: column; gap: 0.4rem; }
   .field-label { display: inline-flex; align-items: center; gap: 0.35rem; font-size: 0.78rem; font-weight: 600; color: var(--text-muted); }
-  .field small { font-size: 0.74rem; color: var(--text-muted); }
 
   .badge {
     display: flex; align-items: center; gap: 0.5rem;
@@ -202,8 +195,6 @@
   .badge-count { font-size: 0.72rem; font-weight: 700; color: var(--brand); background: rgba(var(--brand-rgb), 0.1); padding: 1px 7px; border-radius: 999px; }
   .badge-clear { display: inline-flex; background: none; border: none; color: var(--text-muted); cursor: pointer; padding: 2px; border-radius: var(--radius); }
   .badge-clear:hover { color: var(--danger); }
-
-  #threshold { width: 100%; accent-color: var(--brand); }
 
   .actions { display: flex; flex-direction: column; gap: 0.5rem; margin-top: auto; padding-top: 0.5rem; }
   .ghost {

--- a/mono/static/export/CHANGELOG.md
+++ b/mono/static/export/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Changelog
 
+### 2.3.0
+- Fix : Audit now parses Excel the same way as the Import route
+  - The audit reads the Excel source with the Import parser (`Question.parseSheet`) and templates (FIN / OLD_BOSA / OLD_FIN) instead of a separate parser, so a file that imports cleanly now audits cleanly
+  - Questions are matched by order/position (the TAO export is generated from the Excel, so they share order and count) instead of fuzzy text similarity — far more reliable matching
+  - Unmatched questions and Excel↔QTI count mismatches are now treated as critical (Bloquant) and fail the audit, instead of being shown as a soft warning
+  - Replaced the audit's match-threshold slider and bespoke column config with an Import-style template picker
+
 ### 2.2.0
 - Feat : Password-protected, encrypted library export
   - Set, change, or remove a password in the Database panel

--- a/mono/tsconfig.json
+++ b/mono/tsconfig.json
@@ -12,7 +12,7 @@
 		"strict": true,
 		"moduleResolution": "bundler"
 	},
-	"exclude": ["src/lib/license/__tests__", "src/lib/library/__tests__"],
+	"exclude": ["src/lib/license/__tests__", "src/lib/library/__tests__", "src/lib/audit/__tests__"],
 	// Path aliases are handled by https://svelte.dev/docs/kit/configuration#alias
 	// except $lib which is handled by https://svelte.dev/docs/kit/configuration#files
 	//


### PR DESCRIPTION
The audit only matched ~5/32 questions and treated unmatched ones as a soft
warning. It used a separate Excel parser and fuzzy Jaro-Winkler matching that
diverged from the Import route.

- Parse the Excel source with the Import parser (Question.parseSheet +
  qcmsToAssessmentItems) via new fromExcel.ts, driven by the Import templates
  (FIN/OLD_BOSA/OLD_FIN) — same pipeline as Import, so what imports cleanly
  audits cleanly.
- Normalize both sides to QTIQuestion and match by order/position instead of
  similarity (the TAO export is generated from the Excel, so they share order
  and count). Similarity is kept only as a per-pair confidence score.
- Fold unmatched / count-mismatch questions into the critical (Bloquant) count
  so the audit FAILS instead of passing/warning.
- Replace the audit's threshold slider and bespoke ExcelConfig UI with an
  Import-style template picker; keep parseExcel/ExcelConfig for library ingest.
- Add audit unit tests; changelog 2.3.0 + version bump.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014hAE76opL5gcYdjWAjZgmQ