### PR TITLE
Fix open-question prompts and add per-question tools badges

### DIFF
--- a/mono/package.json
+++ b/mono/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "mono",
 	"private": true,
-	"version": "2.7.4",
+	"version": "2.8.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/mono/package.json
+++ b/mono/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "mono",
 	"private": true,
-	"version": "2.8.0",
+	"version": "2.8.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/mono/src/lib/export/template/Question.svelte
+++ b/mono/src/lib/export/template/Question.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { AssessmentItem } from '$lib/questions/types.js';
   import Qcm from './QCM.svelte';
+  import ExamToolsBadge from '$lib/questions/ExamToolsBadge.svelte';
 
   interface Props {
     item: AssessmentItem;
@@ -35,6 +36,11 @@
     </div>
     {#if item.type === 'single-choice' || item.type === 'multiple-choice'}
       <Qcm {item} />
+    {/if}
+    {#if item.metadata?.tools}
+      <div class="item-tools">
+        <ExamToolsBadge tools={item.metadata.tools} />
+      </div>
     {/if}
   </div>
 {:else}
@@ -86,6 +92,11 @@
   .prompt {
     padding: 8px;
     line-height: 1.5;
+  }
+
+  .item-tools {
+    padding: 6px 8px 10px;
+    border-top: 1px solid var(--border);
   }
 
   /* Each QTI grid-row is its own full-width row that stacks vertically;

--- a/mono/src/lib/questions/ExamToolsBadge.svelte
+++ b/mono/src/lib/questions/ExamToolsBadge.svelte
@@ -33,9 +33,13 @@
 				{formatTime(timeLimits.maxTime)}
 			</span>
 		{/if}
-		{#each enabledTools as tool (tool.key)}
-			<span class="badge">{tool.label}</span>
-		{/each}
+		{#if enabledTools.length > 0}
+			<span class="tools-group hide-print">
+				{#each enabledTools as tool (tool.key)}
+					<span class="badge">{tool.label}</span>
+				{/each}
+			</span>
+		{/if}
 	</div>
 {/if}
 
@@ -65,5 +69,9 @@
 	.badge-time {
 		color: var(--text);
 		border-color: var(--border-strong);
+	}
+
+	.tools-group {
+		display: contents;
 	}
 </style>

--- a/mono/src/lib/questions/adapters/qti.ts
+++ b/mono/src/lib/questions/adapters/qti.ts
@@ -223,7 +223,9 @@ function itemKey(path: string): string {
 
 const instructionLikeTitles = new Set([
 	'exemple question à choix multiple',
-	'voorbeeld meerkeuzevraag'
+	'voorbeeld meerkeuzevraag',
+	'exemple question ouverte',
+	'voorbeeld open vraag'
 ]);
 
 function isInstructionLikeTitle(title: string, label?: string): boolean {
@@ -265,15 +267,22 @@ function parseItem(
 				? gridRows.filter((el) => el.getElementsByTagName('simpleChoice').length === 0)
 				: gridRows;
 			contentHtml = promptRows.map((el) => el.outerHTML).join('');
-			// Include <prompt> element content for choice/text interactions
+			// Include <prompt> element content for interactions whose row got filtered
+			// out of promptRows above (choiceInteraction rows containing simpleChoice).
+			// Rows are never filtered for extendedTextInteraction/textEntryInteraction,
+			// so their <prompt> is already part of contentHtml and must not be re-added.
 			if (hasChoice || hasExtended) {
 				const promptEls = Array.from(
 					doc.querySelectorAll(
 						'choiceInteraction > prompt, extendedTextInteraction > prompt, textEntryInteraction > prompt'
 					)
 				);
-				const extra = promptEls.map((el) => el.innerHTML).join('');
-				if (extra && !contentHtml.includes(extra)) contentHtml += extra;
+				const missingPromptEls = promptEls.filter((el) => {
+					const row = el.closest('.grid-row');
+					return !row || !promptRows.includes(row);
+				});
+				const extra = missingPromptEls.map((el) => el.innerHTML).join('');
+				if (extra) contentHtml += extra;
 			}
 		} else {
 			contentHtml = itemBody.innerHTML;

--- a/mono/src/routes/export/+page.svelte
+++ b/mono/src/routes/export/+page.svelte
@@ -202,7 +202,7 @@
           {#if $activeItems.length > 0}
             {@const activeAssessment = $assessments[$examsIndex]}
             {#if activeAssessment}
-              <div class="exam-header hide-print">
+              <div class="exam-header">
                 <ExamToolsBadge
                   tools={activeAssessment.metadata.tools}
                   timeLimits={activeAssessment.metadata.timeLimits}

--- a/mono/static/export/CHANGELOG.md
+++ b/mono/static/export/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Changelog
 
+### 2.8.0
+- Fix : Open-question ("QO"/"OV") prompts no longer appear twice in the export
+  - The extra-prompt dedup check compared serialized HTML strings, which silently failed for open questions because the XML serializer re-declares the inherited namespace on isolated fragments; it now checks DOM ancestry instead
+- Fix : "Exemple question ouverte" / "Voorbeeld open vraag" are now recognized as instruction pages
+  - They're hidden/shown together with the other instructions via the existing "Show Instructions" setting, matching the QCM example page
+- Feat : Each question now shows its own TAO tools badge (Zoom, Highlighter, Calculator, Review screen, …) below its content, instead of only once for the whole exam
+
 ### 2.7.4
 - Improve : Presentation deck remembers the current slide in the URL
   - Each slide updates `?slide=N` (shallow routing, no navigation), so a reload or a shared link lands on the same slide instead of resetting to the cover

--- a/mono/static/export/CHANGELOG.md
+++ b/mono/static/export/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 2.8.1
+- Fix : The exam's extracted time limit is now visible in the printed/PDF export
+  - The time badge was wrapped in a `hide-print` container together with the on-screen-only tool badges (Zoom, Highlighter, …); it now prints while those screen-only badges stay hidden
+
 ### 2.8.0
 - Fix : Open-question ("QO"/"OV") prompts no longer appear twice in the export
   - The extra-prompt dedup check compared serialized HTML strings, which silently failed for open questions because the XML serializer re-declares the inherited namespace on isolated fragments; it now checks DOM ancestry instead


### PR DESCRIPTION
## Summary
This PR fixes issues with open-question prompt handling in QTI exports and adds per-question tool badges to the export template. It also recognizes French and Dutch open-question instruction pages.

## Key Changes

- **Fixed duplicate open-question prompts**: Replaced string-based HTML comparison with DOM ancestry checking to properly deduplicate prompts. The previous approach failed silently for open questions because XML serialization re-declares inherited namespaces on isolated fragments.

- **Added open-question instruction page recognition**: Extended the `instructionLikeTitles` set to include "exemple question ouverte" (French) and "voorbeeld open vraag" (Dutch), so they're now hidden/shown together with other instruction pages via the "Show Instructions" setting.

- **Added per-question tools badges**: Each question now displays its own TAO tools badge (Zoom, Highlighter, Calculator, Review screen, etc.) below its content, instead of showing a single badge for the entire exam. The badge is rendered conditionally when `item.metadata.tools` is present.

- **Updated styling**: Added `.item-tools` class with appropriate padding and border styling to visually separate the tools badge from question content.

## Implementation Details

- The prompt deduplication logic now filters `promptEls` to only include those whose parent `.grid-row` is either missing or not in the `promptRows` array, avoiding the namespace serialization issue.
- The `ExamToolsBadge` component is imported and conditionally rendered in the Question template.
- Version bumped to 2.8.0 with changelog entries documenting all fixes and features.

https://claude.ai/code/session_01X6tqjoDvij6UNGNVpgyb8n