### PR TITLE
fix: dedupe each-block keys for repeated QTI item ids

### DIFF
--- a/mono/package-lock.json
+++ b/mono/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "mono",
-	"version": "2.10.1",
+	"version": "2.12.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "mono",
-			"version": "2.10.1",
+			"version": "2.12.1",
 			"dependencies": {
 				"@sqlite.org/sqlite-wasm": "^3.53.0-build1",
 				"@sveltejs/adapter-cloudflare": "^7.2.8",

--- a/mono/package.json
+++ b/mono/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "mono",
 	"private": true,
-	"version": "2.12.0",
+	"version": "2.12.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/mono/src/lib/import/preview/MetaMatrix.svelte
+++ b/mono/src/lib/import/preview/MetaMatrix.svelte
@@ -40,7 +40,7 @@
       {/each}
     </div>
     <div class="grid-body">
-      {#each items as item, i (item.id)}
+      {#each items as item, i (item.id + '-' + i)}
         <div class="grid-row" role="row">
           <span class="cell-q" role="cell" title={item.title}>{item.title || `#${i + 1}`}</span>
           {#each model.dimensions as dim (dim.key)}

--- a/mono/src/routes/export/+page.svelte
+++ b/mono/src/routes/export/+page.svelte
@@ -107,7 +107,7 @@
                   </div>
                 </div>
               {/if}
-              {#each $assessments[$compareExamIndex1]?.sections.flatMap(s => s.items) ?? [] as item (item.id)}
+              {#each $assessments[$compareExamIndex1]?.sections.flatMap(s => s.items) ?? [] as item, i (item.id + '-' + i)}
                 {@const show = itemVisible(item.id, item.type)}
                 <Question {item} {show} onToggleShow={(s) => toggleItemShow(item.id, s)} />
               {/each}
@@ -126,7 +126,7 @@
                   </div>
                 </div>
               {/if}
-              {#each $assessments[$compareExamIndex2]?.sections.flatMap(s => s.items) ?? [] as item (item.id)}
+              {#each $assessments[$compareExamIndex2]?.sections.flatMap(s => s.items) ?? [] as item, i (item.id + '-' + i)}
                 {@const show = itemVisible(item.id, item.type)}
                 <Question {item} {show} onToggleShow={(s) => toggleItemShow(item.id, s)} />
               {/each}
@@ -180,7 +180,7 @@
                 />
               </div>
             {/if}
-            {#each $activeItems as item (item.id)}
+            {#each $activeItems as item, i (item.id + '-' + i)}
               {@const show = itemVisible(item.id, item.type)}
               <Question {item} {show} onToggleShow={(s) => toggleItemShow(item.id, s)} />
             {/each}

--- a/mono/src/routes/import/+page.svelte
+++ b/mono/src/routes/import/+page.svelte
@@ -140,7 +140,7 @@
           </div>
         {/if}
 
-        {#each renderItems as item (item.id)}
+        {#each renderItems as item, i (item.id + '-' + i)}
           {@const show = itemVisibility.get(item.id) !== false}
           <div class="question-block">
             <QuestionPreview

--- a/mono/static/export/CHANGELOG.md
+++ b/mono/static/export/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 2.12.1
+- Fix : Importing/exporting a TAO zip whose test references the same item more than once no longer crashes with a Svelte `each_key_duplicate` error
+  - The question lists in Export, Import and the metadata matrix now key each rendered item by id **and** position, so repeated items render instead of throwing
+
 ### 2.12.0
 - Feat : Library search results can now be viewed as a list, a table or cards
   - The layout switcher sits next to the result count; matched terms stay highlighted in every view


### PR DESCRIPTION
TAO zips whose test.xml references the same item more than once produced duplicate ids when flattened into a single question list, crashing Svelte's keyed each blocks (each_key_duplicate) on /export, /import and the metadata matrix. Key by id + position instead so repeated items render.


Claude-Session: https://claude.ai/code/session_01NdxtgPVrqSRkGm36nQH6o7